### PR TITLE
Fixed explicit API mode not working on multiplatform projects

### DIFF
--- a/.idea/artifacts/orbit_core_jvm.xml
+++ b/.idea/artifacts/orbit_core_jvm.xml
@@ -1,0 +1,8 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="orbit-core-jvm">
+    <output-path>$PROJECT_DIR$/orbit-core/build/libs</output-path>
+    <root id="archive" name="orbit-core-jvm.jar">
+      <element id="module-output" name="orbit-mvi.orbit-core.jvmMain" />
+    </root>
+  </artifact>
+</component>

--- a/.idea/artifacts/orbit_test_jvm.xml
+++ b/.idea/artifacts/orbit_test_jvm.xml
@@ -1,0 +1,8 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="orbit-test-jvm">
+    <output-path>$PROJECT_DIR$/orbit-test/build/libs</output-path>
+    <root id="archive" name="orbit-test-jvm.jar">
+      <element id="module-output" name="orbit-mvi.orbit-test.jvmMain" />
+    </root>
+  </artifact>
+</component>

--- a/.idea/artifacts/test_common_jvm.xml
+++ b/.idea/artifacts/test_common_jvm.xml
@@ -1,0 +1,8 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="test-common-jvm">
+    <output-path>$PROJECT_DIR$/test-common/build/libs</output-path>
+    <root id="archive" name="test-common-jvm.jar">
+      <element id="module-output" name="orbit-mvi.test-common.jvmMain" />
+    </root>
+  </artifact>
+</component>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,15 +7,6 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -31,5 +31,10 @@
       <option name="name" value="maven2" />
       <option name="url" value="https://dl.bintray.com/lisawray/maven" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:$USER_HOME$/.m2/repository/" />
+    </remote-repository>
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,6 +145,20 @@ subprojects {
             explicitApi()
         }
     }
+    plugins.withType<org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper> {
+        apply(from = "$rootDir/gradle/scripts/jacoco.gradle.kts")
+        configure<org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension> {
+            // for strict mode
+            explicitApi()
+        }
+    }
+    plugins.withType<org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper> {
+        apply(from = "$rootDir/gradle/scripts/jacoco.gradle.kts")
+        configure<org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension> {
+            // for strict mode
+            explicitApi()
+        }
+    }
     plugins.withId("com.android.library") {
         plugins.withType<org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper> {
             configure<org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension> {

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -27,7 +27,7 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
         delegate.value.orbit(orbitFlow)
     }
 
-    fun test(
+    public fun test(
         initialState: STATE,
         isolateFlow: Boolean = true,
         blocking: Boolean = true

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
@@ -134,7 +134,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.as
     )
 }
 
-class TestFixtures<STATE : Any, SIDE_EFFECT : Any>(
+private class TestFixtures<STATE : Any, SIDE_EFFECT : Any>(
     val initialState: STATE,
     val stateObserver: TestFlowObserver<STATE>,
     val sideEffectObserver: TestFlowObserver<SIDE_EFFECT>,
@@ -143,6 +143,6 @@ class TestFixtures<STATE : Any, SIDE_EFFECT : Any>(
 
 private val testHarness = TestHarness()
 
-class TestHarness {
+private class TestHarness {
     val fixtures = atomic<Map<ContainerHost<*, *>, TestFixtures<*, *>>>(mapOf())
 }

--- a/test-common/src/commonMain/kotlin/org/orbitmvi/orbit/test/Assertions.kt
+++ b/test-common/src/commonMain/kotlin/org/orbitmvi/orbit/test/Assertions.kt
@@ -55,10 +55,10 @@ public fun CharSequence?.assertContains(expected: Regex) {
 }
 
 /** Assert that a collection contains exactly the given values and nothing else, in order. */
-public fun <T> Collection<T>.assertContainExactly(vararg expected: T) = assertContainExactly(expected.asList())
+public fun <T> Collection<T>.assertContainExactly(vararg expected: T): Unit = assertContainExactly(expected.asList())
 
 /** Assert that a collection contains exactly the given values and nothing else, in order. */
-public fun <T> Collection<T>.assertEmpty() = assertContainExactly(emptyList())
+public fun <T> Collection<T>.assertEmpty(): Unit = assertContainExactly(emptyList())
 
 /** Assert that a collection contains exactly the given values and nothing else, in order. */
 public fun <T, C : Collection<T>> C.assertContainExactly(expected: C) {

--- a/test-common/src/commonMain/kotlin/org/orbitmvi/orbit/test/IgnoreIos.kt
+++ b/test-common/src/commonMain/kotlin/org/orbitmvi/orbit/test/IgnoreIos.kt
@@ -20,4 +20,4 @@ package org.orbitmvi.orbit.test
 @OptionalExpectation
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
-expect annotation class IgnoreIos()
+public expect annotation class IgnoreIos()

--- a/test-common/src/iosMain/kotlin/org/orbitmvi/orbit/test/IgnoreIos.kt
+++ b/test-common/src/iosMain/kotlin/org/orbitmvi/orbit/test/IgnoreIos.kt
@@ -16,4 +16,4 @@
 
 package org.orbitmvi.orbit.test
 
-actual typealias IgnoreIos = kotlin.test.Ignore
+public actual typealias IgnoreIos = kotlin.test.Ignore

--- a/test-common/src/jvmMain/kotlin/org/orbitmvi/orbit/test/Blocking.kt
+++ b/test-common/src/jvmMain/kotlin/org/orbitmvi/orbit/test/Blocking.kt
@@ -19,5 +19,5 @@ package org.orbitmvi.orbit.test
 import kotlin.coroutines.CoroutineContext
 
 public actual fun <T> runBlocking(block: suspend () -> T): T = kotlinx.coroutines.runBlocking { block() }
-actual fun <T> runBlocking(coroutineContext: CoroutineContext, block: suspend () -> T): T =
+public actual fun <T> runBlocking(coroutineContext: CoroutineContext, block: suspend () -> T): T =
     kotlinx.coroutines.runBlocking(coroutineContext) { block() }


### PR DESCRIPTION
When we changed the kotlin plugin type the explicit API mode failed to apply.