### PR TITLE
Replaced `Flow` with `StateFlow` for state emissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -96,6 +96,12 @@ jobs:
           path: ~/.gradle/wrapper/dists
           key: ${{ runner.os }}-gradlewrapper
 
+      - name: konan cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('**') }}
+
       - name: Unit tests
         run: ./gradlew check -xlint
 
@@ -107,12 +113,12 @@ jobs:
           path: '**/build/reports/tests/**'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.7
+        uses: codecov/codecov-action@v1.4.1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 
   build:
-    needs: [static-checks, lint, unit-tests]
+    needs: [ static-checks, lint, unit-tests ]
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v2
@@ -135,6 +141,12 @@ jobs:
         with:
           path: ~/.gradle/wrapper/dists
           key: ${{ runner.os }}-gradlewrapper
+
+      - name: konan cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('**') }}
 
       - name: Build
         run: ./gradlew clean assemble -xassembleDebug

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('**') }}
+          key: ${{ runner.os }}-konan
 
       - name: Unit tests
         run: ./gradlew check -xlint
@@ -146,7 +146,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('**') }}
+          key: ${{ runner.os }}-konan
 
       - name: Build
         run: ./gradlew clean assemble -xassembleDebug

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
@@ -20,14 +20,15 @@
 
 package org.orbitmvi.orbit
 
-import org.orbitmvi.orbit.idling.IdlingResource
-import org.orbitmvi.orbit.idling.NoopIdlingResource
-import org.orbitmvi.orbit.internal.defaultBackgroundDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import org.orbitmvi.orbit.idling.IdlingResource
+import org.orbitmvi.orbit.idling.NoopIdlingResource
+import org.orbitmvi.orbit.internal.defaultBackgroundDispatcher
 import org.orbitmvi.orbit.syntax.ContainerContext
 
 /**
@@ -39,16 +40,12 @@ import org.orbitmvi.orbit.syntax.ContainerContext
  * container never posts side effects.
  */
 public interface Container<STATE : Any, SIDE_EFFECT : Any> {
-    /**
-     * The container's current state.
-     */
-    public val currentState: STATE
 
     /**
-     * A [Flow] of state updates. Emits the latest state upon subscription and serves only distinct
+     * A [StateFlow] of state updates. Emits the latest state upon subscription and serves only distinct
      * values (through equality comparison).
      */
-    public val stateFlow: Flow<STATE>
+    public val stateFlow: StateFlow<STATE>
 
     /**
      * A [Flow] of one-off side effects posted from [Container]. Caches side effects when there are no collectors.

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
@@ -35,14 +35,12 @@ public class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
 ) : ContainerDecorator<STATE, SIDE_EFFECT> {
     private val created = atomic<Int>(0)
 
-    override val stateFlow: StateFlow<STATE>
-        get() = actual.stateFlow.onSubscribe { runOnCreate() }
+    override val stateFlow: StateFlow<STATE> = actual.stateFlow.onSubscribe { runOnCreate() }
 
-    override val sideEffectFlow: Flow<SIDE_EFFECT>
-        get() = flow {
-            runOnCreate()
-            emitAll(actual.sideEffectFlow)
-        }
+    override val sideEffectFlow: Flow<SIDE_EFFECT> = flow {
+        runOnCreate()
+        emitAll(actual.sideEffectFlow)
+    }
 
     private fun runOnCreate() {
         if (created.compareAndSet(0, 1)) {

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -28,6 +28,8 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -49,9 +51,7 @@ public open class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
     private val initialised = atomic(false)
 
     private val internalStateFlow = MutableStateFlow(initialState)
-    override val currentState: STATE
-        get() = internalStateFlow.value
-    override val stateFlow: Flow<STATE> = internalStateFlow
+    override val stateFlow: StateFlow<STATE> = internalStateFlow.asStateFlow()
 
     private val sideEffectChannel = Channel<SIDE_EFFECT>(settings.sideEffectBufferSize)
     override val sideEffectFlow: Flow<SIDE_EFFECT> = sideEffectChannel.receiveAsFlow()

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/StateFlowExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/StateFlowExtensions.kt
@@ -1,0 +1,23 @@
+package org.orbitmvi.orbit.internal
+
+import kotlinx.coroutines.flow.AbstractFlow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+
+@Suppress("EXPERIMENTAL_API_USAGE", "EXPERIMENTAL_OVERRIDE")
+internal fun <T> StateFlow<T>.onSubscribe(block: () -> Unit): StateFlow<T> =
+    object : AbstractFlow<T>(), StateFlow<T> {
+        override val replayCache: List<T>
+            get() = this@onSubscribe.replayCache
+
+        override val value: T
+            get() = this@onSubscribe.value
+
+        override suspend fun collectSafely(collector: FlowCollector<T>) {
+            block()
+            this@onSubscribe.collect {
+                collector.emit(it)
+            }
+        }
+    }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -3,6 +3,7 @@ package org.orbitmvi.orbit.internal
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerDecorator
 import org.orbitmvi.orbit.syntax.ContainerContext
@@ -14,10 +15,7 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
 
     private val delegate = atomic(actual)
 
-    override val currentState: STATE
-        get() = delegate.value.currentState
-
-    override val stateFlow: Flow<STATE>
+    override val stateFlow: StateFlow<STATE>
         get() = delegate.value.stateFlow
 
     override val sideEffectFlow: Flow<SIDE_EFFECT>

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
@@ -57,7 +57,7 @@ internal class ContainerExceptionHandlerTest {
             reduce { newState }
         }
 
-        assertEquals(initState, container.currentState)
+        assertEquals(initState, container.stateFlow.value)
         assertEquals(false, scope.isActive)
     }
 
@@ -82,7 +82,7 @@ internal class ContainerExceptionHandlerTest {
             reduce { newState }
         }
 
-        assertEquals(newState, container.currentState)
+        assertEquals(newState, container.stateFlow.value)
         assertEquals(true, scope.isActive)
         assertEquals(1, exceptions.size)
         assertTrue { exceptions.first() is IllegalStateException }

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerThreadingTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerThreadingTest.kt
@@ -60,7 +60,7 @@ internal class ContainerThreadingTest {
         }
 
         observer.awaitCount(2)
-        assertEquals(newState, container.currentState)
+        assertEquals(newState, container.stateFlow.value)
     }
 
     @Test

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/StateTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/StateTest.kt
@@ -84,7 +84,7 @@ internal class StateTest {
         val initialState = TestState()
         val middleware = Middleware(initialState)
 
-        assertEquals(initialState, middleware.container.currentState)
+        assertEquals(initialState, middleware.container.stateFlow.value)
     }
 
     @Test
@@ -98,7 +98,7 @@ internal class StateTest {
 
         testStateObserver.awaitCount(2)
 
-        assertEquals(testStateObserver.values.last(), middleware.container.currentState)
+        assertEquals(testStateObserver.values.last(), middleware.container.stateFlow.value)
     }
 
     private data class TestState(val id: Int = Random.nextInt())

--- a/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/SavedStateContainerDecorator.kt
+++ b/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/SavedStateContainerDecorator.kt
@@ -22,8 +22,7 @@ package org.orbitmvi.orbit.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.StateFlow
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerDecorator
 import org.orbitmvi.orbit.syntax.ContainerContext
@@ -32,16 +31,12 @@ internal class SavedStateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     override val actual: Container<STATE, SIDE_EFFECT>,
     private val savedStateHandle: SavedStateHandle
 ) : ContainerDecorator<STATE, SIDE_EFFECT> {
-    override val currentState: STATE
-        get() = actual.currentState
 
-    override val stateFlow: Flow<STATE>
-        get() = flow {
-            actual.stateFlow.collect {
-                savedStateHandle[SAVED_STATE_KEY] = it
-                emit(it)
-            }
+    override val stateFlow: StateFlow<STATE>
+        get() = actual.stateFlow.onEach {
+            savedStateHandle[SAVED_STATE_KEY] = it
         }
+
     override val sideEffectFlow: Flow<SIDE_EFFECT>
         get() = actual.sideEffectFlow
 

--- a/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/SavedStateContainerDecorator.kt
+++ b/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/SavedStateContainerDecorator.kt
@@ -32,10 +32,11 @@ internal class SavedStateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     private val savedStateHandle: SavedStateHandle
 ) : ContainerDecorator<STATE, SIDE_EFFECT> {
 
-    override val stateFlow: StateFlow<STATE>
-        get() = actual.stateFlow.onEach {
+    override val stateFlow: StateFlow<STATE> by lazy {
+        actual.stateFlow.onEach {
             savedStateHandle[SAVED_STATE_KEY] = it
         }
+    }
 
     override val sideEffectFlow: Flow<SIDE_EFFECT>
         get() = actual.sideEffectFlow

--- a/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/StateFlowExtensions.kt
+++ b/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/StateFlowExtensions.kt
@@ -1,0 +1,23 @@
+package org.orbitmvi.orbit.viewmodel
+
+import kotlinx.coroutines.flow.AbstractFlow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+
+@Suppress("EXPERIMENTAL_API_USAGE", "EXPERIMENTAL_OVERRIDE")
+internal fun <T> StateFlow<T>.onEach(block: (T) -> Unit): StateFlow<T> =
+    object : AbstractFlow<T>(), StateFlow<T> {
+        override val replayCache: List<T>
+            get() = this@onEach.replayCache
+
+        override val value: T
+            get() = this@onEach.value
+
+        override suspend fun collectSafely(collector: FlowCollector<T>) {
+            this@onEach.collect {
+                block(it)
+                collector.emit(it)
+            }
+        }
+    }

--- a/orbit-viewmodel/src/test/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensionsKtTest.kt
+++ b/orbit-viewmodel/src/test/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensionsKtTest.kt
@@ -41,7 +41,7 @@ class ViewModelExtensionsKtTest {
 
         val middleware = Middleware(savedStateHandle, initialState)
 
-        assertEquals(savedState, middleware.container.currentState)
+        assertEquals(savedState, middleware.container.stateFlow.value)
     }
 
     @Test
@@ -51,7 +51,7 @@ class ViewModelExtensionsKtTest {
 
         val middleware = Middleware(savedStateHandle, initialState)
 
-        assertEquals(initialState, middleware.container.currentState)
+        assertEquals(initialState, middleware.container.stateFlow.value)
     }
 
     @Test


### PR DESCRIPTION
#36 Needs to be go in first

`StateFlow` is a more appropriate type for our use case for state emissions and allows us to get rid of `currentState` from the API as you can read the current state through `stateFlow.value`.