### PR TITLE
Add container exception handler support

### DIFF
--- a/orbit-core/README.md
+++ b/orbit-core/README.md
@@ -309,6 +309,10 @@ done by switching your coroutine context.
 ## Error handling
 
 It is good practice to handle all of your errors within your flows.
-Orbit does not provide any built-in exception handling because it cannot
-make assumptions about how you respond to errors, avoiding putting your
-system in an undefined state.
+By default Orbit doesn't handle or process any exceptions because it cannot
+make assumptions about how you respond to errors. However you could install
+default exception handler via
+[Container Settings](src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt)
+property `orbitExceptionHandler` -> if defined exceptions are caught here so
+parent scope is not affected and Orbit container
+would continue to operate normally.

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
@@ -24,6 +24,7 @@ import org.orbitmvi.orbit.idling.IdlingResource
 import org.orbitmvi.orbit.idling.NoopIdlingResource
 import org.orbitmvi.orbit.internal.defaultBackgroundDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -82,6 +83,7 @@ public interface Container<STATE : Any, SIDE_EFFECT : Any> {
         public val sideEffectBufferSize: Int = Channel.UNLIMITED,
         public val idlingRegistry: IdlingResource = NoopIdlingResource(),
         public val orbitDispatcher: CoroutineDispatcher = Dispatchers.Default,
+        public val orbitExceptionHandler: CoroutineExceptionHandler? = null,
         public val backgroundDispatcher: CoroutineDispatcher = defaultBackgroundDispatcher,
     )
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
@@ -83,7 +83,7 @@ public interface Container<STATE : Any, SIDE_EFFECT : Any> {
         public val sideEffectBufferSize: Int = Channel.UNLIMITED,
         public val idlingRegistry: IdlingResource = NoopIdlingResource(),
         public val orbitDispatcher: CoroutineDispatcher = Dispatchers.Default,
-        public val orbitExceptionHandler: CoroutineExceptionHandler? = null,
         public val backgroundDispatcher: CoroutineDispatcher = defaultBackgroundDispatcher,
+        public val exceptionHandler: CoroutineExceptionHandler? = null,
     )
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.orbitmvi.orbit.Container
@@ -77,7 +78,13 @@ public open class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
             }
             scope.launch {
                 for (msg in dispatchChannel) {
-                    launch(Dispatchers.Unconfined) { pluginContext.msg() }
+                    if (settings.orbitExceptionHandler == null) {
+                        launch(Dispatchers.Unconfined) { pluginContext.msg() }
+                    } else {
+                        supervisorScope {
+                            launch(settings.orbitExceptionHandler + Dispatchers.Unconfined) { pluginContext.msg() }
+                        }
+                    }
                 }
             }
         }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -78,11 +78,11 @@ public open class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
             }
             scope.launch {
                 for (msg in dispatchChannel) {
-                    if (settings.orbitExceptionHandler == null) {
+                    if (settings.exceptionHandler == null) {
                         launch(Dispatchers.Unconfined) { pluginContext.msg() }
                     } else {
                         supervisorScope {
-                            launch(settings.orbitExceptionHandler + Dispatchers.Unconfined) { pluginContext.msg() }
+                            launch(settings.exceptionHandler + Dispatchers.Unconfined) { pluginContext.msg() }
                         }
                     }
                 }

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2020 Babylon Partners Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * File modified by Mikołaj Leszczyński & Appmattus Limited
+ * See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
+ */
+
+package org.orbitmvi.orbit.internal
+
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.container
+import org.orbitmvi.orbit.test
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@ExperimentalCoroutinesApi
+internal class ContainerExceptionHandlerTest {
+
+    private val scope = CoroutineScope(Job() + CoroutineExceptionHandler { _, _ -> /*just be silent*/ })
+
+    @AfterTest
+    fun afterTest() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `by default any exception breaks the scope`() = runBlocking {
+        val initState = Random.nextInt()
+        val container = scope.container<Int, Nothing>(initState)
+        val observer = container.stateFlow.test()
+        val newState = Random.nextInt()
+
+        container.orbit {
+            throw IllegalStateException()
+        }
+        container.orbit {
+            reduce { newState }
+        }
+
+        observer.awaitCount(2)
+        assertEquals(initState, container.currentState)
+        assertEquals(false, scope.isActive)
+    }
+
+    @Test
+    fun `with exception handler exceptions are caught`() {
+        val initState = Random.nextInt()
+        val exceptions = mutableListOf<Throwable>()
+        val exceptionHandler = CoroutineExceptionHandler { _, throwable -> exceptions += throwable }
+        val container = scope.container<Int, Nothing>(
+                initialState = initState,
+                settings = Container.Settings(
+                        orbitDispatcher = Dispatchers.Unconfined,
+                        orbitExceptionHandler = exceptionHandler
+                )
+        )
+        val observer = container.stateFlow.test()
+        val newState = Random.nextInt()
+
+        container.orbit {
+            reduce { throw IllegalStateException() }
+        }
+        container.orbit {
+            reduce { newState }
+        }
+
+        observer.awaitCount(2)
+        assertEquals(newState, container.currentState)
+        assertEquals(true, scope.isActive)
+        assertEquals(1, exceptions.size)
+        assertTrue { exceptions.first() is IllegalStateException }
+    }
+}

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
@@ -1,6 +1,5 @@
 /*
  * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
- * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * File modified by Mikołaj Leszczyński & Appmattus Limited
- * See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
  */
 
 package org.orbitmvi.orbit.internal
@@ -29,7 +25,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.container
-import org.orbitmvi.orbit.test
 import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -49,8 +44,10 @@ internal class ContainerExceptionHandlerTest {
     @Test
     fun `by default any exception breaks the scope`() = runBlocking {
         val initState = Random.nextInt()
-        val container = scope.container<Int, Nothing>(initState)
-        val observer = container.stateFlow.test()
+        val container = scope.container<Int, Nothing>(
+                initialState = initState,
+                settings = Container.Settings(orbitDispatcher = Dispatchers.Unconfined)
+        )
         val newState = Random.nextInt()
 
         container.orbit {
@@ -60,7 +57,6 @@ internal class ContainerExceptionHandlerTest {
             reduce { newState }
         }
 
-        observer.awaitCount(2)
         assertEquals(initState, container.currentState)
         assertEquals(false, scope.isActive)
     }
@@ -74,10 +70,9 @@ internal class ContainerExceptionHandlerTest {
                 initialState = initState,
                 settings = Container.Settings(
                         orbitDispatcher = Dispatchers.Unconfined,
-                        orbitExceptionHandler = exceptionHandler
+                        exceptionHandler = exceptionHandler
                 )
         )
-        val observer = container.stateFlow.test()
         val newState = Random.nextInt()
 
         container.orbit {
@@ -87,7 +82,6 @@ internal class ContainerExceptionHandlerTest {
             reduce { newState }
         }
 
-        observer.awaitCount(2)
         assertEquals(newState, container.currentState)
         assertEquals(true, scope.isActive)
         assertEquals(1, exceptions.size)

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/ui/PostListItem.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/ui/PostListItem.kt
@@ -49,5 +49,10 @@ data class PostListItem(private val post: PostOverview, private val viewModel: P
         viewBinding.root.setOnClickListener {
             viewModel.onPostClicked(post)
         }
+
+        viewBinding.root.setOnLongClickListener {
+            viewModel.onPostLongClicked()
+            true
+        }
     }
 }

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
@@ -20,8 +20,11 @@
 
 package org.orbitmvi.orbit.sample.posts.app.features.postlist.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.CoroutineExceptionHandler
+import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.sample.posts.app.common.NavigationEvent
 import org.orbitmvi.orbit.sample.posts.domain.repositories.PostOverview
@@ -33,10 +36,17 @@ import org.orbitmvi.orbit.viewmodel.container
 
 class PostListViewModel(
     savedStateHandle: SavedStateHandle,
-    private val postRepository: PostRepository
+    private val postRepository: PostRepository,
+    exceptionHandler: CoroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        Log.w("PostListViewModel", "orbit caught the exception", throwable)
+    }
 ) : ViewModel(), ContainerHost<PostListState, NavigationEvent> {
 
-    override val container = container<PostListState, NavigationEvent>(PostListState(), savedStateHandle) {
+    override val container = container<PostListState, NavigationEvent>(
+        initialState = PostListState(),
+        savedStateHandle = savedStateHandle,
+        settings = Container.Settings(orbitExceptionHandler = exceptionHandler)
+    ) {
         if (it.overviews.isEmpty()) {
             loadOverviews()
         }
@@ -52,5 +62,9 @@ class PostListViewModel(
 
     fun onPostClicked(post: PostOverview) = intent {
         postSideEffect(OpenPostNavigationEvent(post))
+    }
+
+    fun onPostLongClicked() = intent {
+        throw IllegalStateException("Catch me!")
     }
 }

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
@@ -45,7 +45,7 @@ class PostListViewModel(
     override val container = container<PostListState, NavigationEvent>(
         initialState = PostListState(),
         savedStateHandle = savedStateHandle,
-        settings = Container.Settings(orbitExceptionHandler = exceptionHandler)
+        settings = Container.Settings(exceptionHandler = exceptionHandler)
     ) {
         if (it.overviews.isEmpty()) {
             loadOverviews()


### PR DESCRIPTION
As discussed at Slack, 
it would be nice to have option to install "default" exception handler for the container, so any exception thrown doesn't affect parent scope (and orbit container). Note, by default (if handler is null) behaviour doesn't change.