### PR TITLE
Fix blocked event loop when exception handler is installed

### DIFF
--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
@@ -18,11 +18,9 @@ package org.orbitmvi.orbit.internal
 
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.container
@@ -47,7 +45,7 @@ internal class ContainerExceptionHandlerTest {
     fun `by default any exception breaks the scope`() = runBlocking {
         val initState = Random.nextInt()
         val container = scope.container<Int, Nothing>(
-                initialState = initState
+            initialState = initState
         )
         val testObserver = container.stateFlow.test()
         val newState = Random.nextInt()
@@ -70,10 +68,10 @@ internal class ContainerExceptionHandlerTest {
         val exceptions = mutableListOf<Throwable>()
         val exceptionHandler = CoroutineExceptionHandler { _, throwable -> exceptions += throwable }
         val container = scope.container<Int, Nothing>(
-                initialState = initState,
-                settings = Container.Settings(
-                        exceptionHandler = exceptionHandler
-                )
+            initialState = initState,
+            settings = Container.Settings(
+                exceptionHandler = exceptionHandler
+            )
         )
         val testObserver = container.stateFlow.test()
         val newState = Random.nextInt()

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
@@ -18,6 +18,7 @@ package org.orbitmvi.orbit.internal
 
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -70,10 +71,10 @@ internal class ContainerExceptionHandlerTest {
         val container = scope.container<Int, Nothing>(
             initialState = initState,
             settings = Container.Settings(
-                exceptionHandler = exceptionHandler
+                exceptionHandler = exceptionHandler,
+                orbitDispatcher = Dispatchers.Unconfined
             )
         )
-        val testObserver = container.stateFlow.test()
         val newState = Random.nextInt()
 
         container.orbit {
@@ -83,8 +84,7 @@ internal class ContainerExceptionHandlerTest {
             reduce { newState }
         }
 
-        testObserver.awaitCount(2, 1000L)
-        assertEquals(listOf(initState, newState), testObserver.values)
+        assertEquals(newState, container.stateFlow.value)
         assertEquals(true, scope.isActive)
         assertEquals(1, exceptions.size)
         assertTrue { exceptions.first() is IllegalStateException }


### PR DESCRIPTION
Intents that never finish (like collecting an infinite flow) would block the event loop due to an errant `supervisorScope` which waited for the launched intent to finish