### PR TITLE
Fix Settings' `exceptionHandler` to be still counted in test() mode

### DIFF
--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
@@ -98,7 +98,7 @@ internal class ContainerExceptionHandlerTest {
     }
 
     @Test
-    fun `with exception handler test() doesn't brake`() {
+    fun `with exception handler test() doesn't break`() {
         val initState = Random.nextInt()
         val exceptions = mutableListOf<Throwable>()
         val exceptionHandler = CoroutineExceptionHandler { _, throwable -> exceptions += throwable }
@@ -135,7 +135,7 @@ internal class ContainerExceptionHandlerTest {
     }
 
     @Test
-    fun `without exception handler test() does brake`() {
+    fun `without exception handler test() does break`() {
         val initState = Random.nextInt()
         val containerHost = object : ContainerHost<Int, Nothing> {
             override val container = scope.container<Int, Nothing>(

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
@@ -30,7 +30,6 @@ import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import org.orbitmvi.orbit.ContainerHost
@@ -154,19 +153,20 @@ internal class ContainerExceptionHandlerTest {
                     }
                 }
             }
-/*
-            // that still works - do we want it to?
+            // Note: another `intent{}` would still work
+            // as `test()` moves all the job to scope of invocation,
+            // and out of a container's scope (so it's ignored)
             val newState = Random.nextInt()
             containerHost.testIntent {
                 intent {
                     reduce { newState }
                 }
             }
-*/
+            containerHost.assert(initState) {
+                states({ newState })
+            }
         }
 
-        containerHost.assert(initState)
-        // that still works - do we want it to?
-//        assertEquals(true, scope.isActive)
+        assertEquals(true, scope.isActive)
     }
 }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
@@ -122,7 +122,7 @@ public class SuspendingTestContainerHost<STATE : Any, SIDE_EFFECT : Any, T : Con
                     launch(context) {
                         intent()
                     }
-                }
+                }.join()
             }
         }
     }


### PR DESCRIPTION
The `exceptionHandler` is completely ignored in `test()` mode -> that means tests are effectively broken even code works nicely in production.