### PR TITLE
Allow non-intent calls

### DIFF
--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
@@ -82,11 +82,7 @@ public class SuspendingTestContainerHost<STATE : Any, SIDE_EFFECT : Any, T : Con
         if (runOnCreate) {
             actual.container.findOnCreate().invoke(initialState)
             runBlocking {
-                // In case onCreate launches an intent
-                runCatching {
-                    // Ignore exception, this will happen if onCreate does not launch an intent
-                    actual.suspendingIntent(false) {}
-                }
+                actual.suspendingIntent(shouldIsolateFlow = false) {}
             }
         }
     }
@@ -107,10 +103,6 @@ public class SuspendingTestContainerHost<STATE : Any, SIDE_EFFECT : Any, T : Con
         val testContainer = container.findTestContainer()
 
         this.block() // Invoke the Intent
-
-        if (testContainer.savedIntents.isEmpty) {
-            throw IllegalArgumentException("testIntent block must invoke an orbit intent!")
-        }
 
         var firstIntentExecuted = false
         while (!testContainer.savedIntents.isEmpty) {


### PR DESCRIPTION
Sometimes we have if-else branches without need to invoke `intent{}`, e.g.:
```
fun onLocationQuery(query: String) {        
        if (query.length < MIN_QUERY_LENGTH_TO_PERFORM_SEARCH) {
            return // no intent needed
        }
        performSuggestionsSearch(query) // intent{} inside, the func is reused later
}
```    