### PR TITLE
Require opt-in for container context

### DIFF
--- a/orbit-core/orbit-core_build.gradle.kts
+++ b/orbit-core/orbit-core_build.gradle.kts
@@ -31,6 +31,10 @@ kotlin {
     jvm()
     ios()
     sourceSets {
+        all {
+            languageSettings.optIn("kotlin.RequiresOptIn")
+            languageSettings.optIn("org.orbitmvi.orbit.annotation.OrbitInternal")
+        }
         commonMain {
             dependencies {
                 implementation(ProjectDependencies.kotlinCoroutines)

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/annotation/OrbitInternal.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/annotation/OrbitInternal.kt
@@ -1,0 +1,6 @@
+package org.orbitmvi.orbit.annotation
+
+@RequiresOptIn(message = "This is an internal API designed for Orbit extensions.")
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+public annotation class OrbitInternal

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/ContainerContext.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/ContainerContext.kt
@@ -1,8 +1,10 @@
 package org.orbitmvi.orbit.syntax
 
 import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.annotation.OrbitInternal
 import org.orbitmvi.orbit.internal.repeatonsubscription.SubscribedCounter
 
+@OrbitInternal
 public class ContainerContext<S : Any, SE : Any>(
     public val settings: Container.Settings,
     public val postSideEffect: suspend (SE) -> Unit,


### PR DESCRIPTION
Making sure people don't use `containerContext` within the standard DSL unless they want to extend the DSL and know what they're doing.