### PR TITLE
Remove NestedScrollView as recycler items were all inflating

### DIFF
--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/MainActivity.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/MainActivity.kt
@@ -22,9 +22,7 @@ package org.orbitmvi.orbit.sample.posts.app.features
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.Toolbar
 import androidx.navigation.findNavController
-import androidx.navigation.ui.setupActionBarWithNavController
 import org.orbitmvi.orbit.sample.posts.R
 
 class MainActivity : AppCompatActivity() {
@@ -34,12 +32,6 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.main_activity)
-
-        findViewById<Toolbar>(R.id.toolbar).apply {
-            setSupportActionBar(this)
-        }
-
-        setupActionBarWithNavController(navController)
     }
 
     override fun onSupportNavigateUp() = navController.navigateUp()

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/ui/PostDetailsFragment.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/ui/PostDetailsFragment.kt
@@ -27,7 +27,9 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
@@ -57,15 +59,15 @@ class PostDetailsFragment : Fragment(R.layout.post_details_fragment) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val appCompatActivity = activity as AppCompatActivity
+        appCompatActivity.setSupportActionBar(binding.toolbar)
+        setupActionBarWithNavController(appCompatActivity, findNavController())
+
         binding.postCommentsList.layoutManager = LinearLayoutManager(activity)
         ViewCompat.setNestedScrollingEnabled(binding.postCommentsList, false)
 
         binding.postCommentsList.addItemDecoration(
-            SeparatorDecoration(
-                requireActivity(),
-                R.dimen.separator_margin_start,
-                R.dimen.separator_margin_end
-            )
+            SeparatorDecoration(requireActivity(), R.dimen.separator_margin_start, R.dimen.separator_margin_end)
         )
 
         binding.postCommentsList.adapter = adapter
@@ -76,7 +78,7 @@ class PostDetailsFragment : Fragment(R.layout.post_details_fragment) {
     private fun render(state: PostDetailState) {
         if (!initialised) {
             initialised = true
-            (activity as AppCompatActivity?)?.supportActionBar?.apply {
+            binding.toolbar.apply {
                 title = state.postOverview.username
                 Glide.with(requireContext()).load(state.postOverview.avatarUrl)
                     .apply(RequestOptions.overrideOf(resources.getDimensionPixelSize(R.dimen.toolbar_logo_size)))

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/ui/PostListFragment.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/ui/PostListFragment.kt
@@ -21,10 +21,7 @@
 package org.orbitmvi.orbit.sample.posts.app.features.postlist.ui
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -49,19 +46,10 @@ class PostListFragment : Fragment(R.layout.post_list_fragment) {
 
     private val adapter = GroupAdapter<GroupieViewHolder>()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-
-        return inflater.inflate(R.layout.post_list_fragment, container, false)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        (activity as AppCompatActivity?)?.supportActionBar?.apply {
+        binding.toolbar.apply {
             setTitle(R.string.app_name)
             setLogo(R.drawable.ic_orbit_toolbar)
         }

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/ui/PostListItem.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/ui/PostListItem.kt
@@ -21,13 +21,13 @@
 package org.orbitmvi.orbit.sample.posts.app.features.postlist.ui
 
 import android.view.View
-import org.orbitmvi.orbit.sample.posts.R
-import org.orbitmvi.orbit.sample.posts.app.features.postlist.viewmodel.PostListViewModel
-import org.orbitmvi.orbit.sample.posts.domain.repositories.PostOverview
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import com.xwray.groupie.viewbinding.BindableItem
+import org.orbitmvi.orbit.sample.posts.R
+import org.orbitmvi.orbit.sample.posts.app.features.postlist.viewmodel.PostListViewModel
 import org.orbitmvi.orbit.sample.posts.databinding.PostListItemBinding
+import org.orbitmvi.orbit.sample.posts.domain.repositories.PostOverview
 
 data class PostListItem(private val post: PostOverview, private val viewModel: PostListViewModel) : BindableItem<PostListItemBinding>() {
 
@@ -48,11 +48,6 @@ data class PostListItem(private val post: PostOverview, private val viewModel: P
 
         viewBinding.root.setOnClickListener {
             viewModel.onPostClicked(post)
-        }
-
-        viewBinding.root.setOnLongClickListener {
-            viewModel.onPostLongClicked()
-            true
         }
     }
 }

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
@@ -63,8 +63,4 @@ class PostListViewModel(
     fun onPostClicked(post: PostOverview) = intent {
         postSideEffect(OpenPostNavigationEvent(post))
     }
-
-    fun onPostLongClicked() = intent {
-        throw IllegalStateException("Catch me!")
-    }
 }

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/data/posts/network/PostNetworkDataSource.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/data/posts/network/PostNetworkDataSource.kt
@@ -58,29 +58,9 @@ class PostNetworkDataSource(private val typicodeService: TypicodeService) {
         }
     }
 
-    suspend fun getUser(id: Int): UserData? {
-        return try {
-            typicodeService.user(id)
-        } catch (ignore: IOException) {
-            null
-        } catch (ignore: HttpException) {
-            null
-        }
-    }
-
     suspend fun getComments(): List<CommentData> {
         return try {
             typicodeService.comments()
-        } catch (ignore: IOException) {
-            emptyList()
-        } catch (ignore: HttpException) {
-            emptyList()
-        }
-    }
-
-    suspend fun getComments(postId: Int): List<CommentData> {
-        return try {
-            typicodeService.comments(postId)
         } catch (ignore: IOException) {
             emptyList()
         } catch (ignore: HttpException) {

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/data/posts/network/TypicodeService.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/data/posts/network/TypicodeService.kt
@@ -34,15 +34,9 @@ interface TypicodeService {
     @GET("posts")
     suspend fun posts(): List<PostData>
 
-    @GET("users/{id}")
-    suspend fun user(@Path("id") id: Int): UserData
-
     @GET("users")
     suspend fun users(): List<UserData>
 
     @GET("comments")
     suspend fun comments(): List<CommentData>
-
-    @GET("posts/{id}/comments")
-    suspend fun comments(@Path("id") postId: Int): List<CommentData>
 }

--- a/samples/orbit-posts/src/main/res/layout/main_activity.xml
+++ b/samples/orbit-posts/src/main/res/layout/main_activity.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
-  ~ Copyright 2020 Babylon Partners Limited
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,46 +12,15 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  ~
-  ~ File modified by Mikołaj Leszczyński & Appmattus Limited
-  ~ See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
   -->
 
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<fragment xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_host_fragment"
+    android:name="androidx.navigation.fragment.NavHostFragment"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/scrollView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="org.orbitmvi.orbit.sample.posts.app.common.ShadowScrollBehavior">
-
-        <fragment
-            android:id="@+id/nav_host_fragment"
-            android:name="androidx.navigation.fragment.NavHostFragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:defaultNavHost="true"
-            app:navGraph="@navigation/nav_graph"
-            tools:ignore="FragmentTagUsage" />
-
-    </androidx.core.widget.NestedScrollView>
-
-    <com.google.android.material.appbar.AppBarLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?android:attr/windowBackground"
-            app:popupTheme="@style/Theme.MaterialComponents.Light.NoActionBar"
-            app:theme="@style/ThemeOverlay.MaterialComponents.ActionBar" />
-
-    </com.google.android.material.appbar.AppBarLayout>
-
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+    android:layout_height="match_parent"
+    app:defaultNavHost="true"
+    app:navGraph="@navigation/nav_graph"
+    tools:ignore="FragmentTagUsage" />

--- a/samples/orbit-posts/src/main/res/layout/post_details_fragment.xml
+++ b/samples/orbit-posts/src/main/res/layout/post_details_fragment.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
-  ~ Copyright 2020 Babylon Partners Limited
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,76 +12,99 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  ~
-  ~ File modified by Mikołaj Leszczyński & Appmattus Limited
-  ~ See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
   -->
-
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/postdetails"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    tools:context="org.orbitmvi.orbit.sample.posts.app.features.postdetails.ui.PostDetailsFragment">
+    android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/post_title"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginTop="16dp"
-        android:layout_marginEnd="16dp"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Headline4"
-        android:transitionName="post_title"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:ignore="UnusedAttribute"
-        tools:targetApi="lollipop"
-        tools:text="@sample/posts.json/data/post_title" />
-
-    <TextView
-        android:id="@+id/post_body"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/post_title"
-        tools:text="@sample/posts.json/data/post_body" />
-
-    <View
-        android:id="@+id/divider"
-        android:layout_width="0dp"
-        android:layout_height="1dp"
-        android:layout_margin="16dp"
-        android:background="@color/separator"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/post_body" />
-
-    <TextView
-        android:id="@+id/post_comment_count"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/divider"
-        tools:text="@sample/posts.json/data/post_comments" />
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/post_comments_list"
+    <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/post_comment_count"
-        tools:listitem="@layout/post_comment_list_item" />
+        android:layout_height="match_parent"
+        app:layout_behavior="org.orbitmvi.orbit.sample.posts.app.common.ShadowScrollBehavior">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/postdetails"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:context="org.orbitmvi.orbit.sample.posts.app.features.postdetails.ui.PostDetailsFragment">
+
+            <TextView
+                android:id="@+id/post_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Headline4"
+                android:transitionName="post_title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="UnusedAttribute"
+                tools:targetApi="lollipop"
+                tools:text="@sample/posts.json/data/post_title" />
+
+            <TextView
+                android:id="@+id/post_body"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/post_title"
+                tools:text="@sample/posts.json/data/post_body" />
+
+            <View
+                android:id="@+id/divider"
+                android:layout_width="0dp"
+                android:layout_height="1dp"
+                android:layout_margin="16dp"
+                android:background="@color/separator"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/post_body" />
+
+            <TextView
+                android:id="@+id/post_comment_count"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/divider"
+                tools:text="@sample/posts.json/data/post_comments" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/post_comments_list"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/post_comment_count"
+                tools:listitem="@layout/post_comment_list_item" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?android:attr/windowBackground"
+            app:popupTheme="@style/Theme.MaterialComponents.Light.NoActionBar"
+            app:theme="@style/ThemeOverlay.MaterialComponents.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/samples/orbit-posts/src/main/res/layout/post_list_fragment.xml
+++ b/samples/orbit-posts/src/main/res/layout/post_list_fragment.xml
@@ -1,7 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
-  ~ Copyright 2020 Babylon Partners Limited
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -14,18 +12,37 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  ~
-  ~ File modified by Mikołaj Leszczyński & Appmattus Limited
-  ~ See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
   -->
-
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/content"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:clipToPadding="false"
-    android:padding="1dp"
-    android:scrollbars="vertical"
-    tools:context="org.orbitmvi.orbit.sample.posts.app.features.postlist.ui.PostListFragment"
-    tools:listitem="@layout/post_list_item" />
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:padding="1dp"
+        android:scrollbars="vertical"
+        app:layout_behavior="org.orbitmvi.orbit.sample.posts.app.common.ShadowScrollBehavior"
+        tools:context="org.orbitmvi.orbit.sample.posts.app.features.postlist.ui.PostListFragment"
+        tools:listitem="@layout/post_list_item" />
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?android:attr/windowBackground"
+            app:popupTheme="@style/Theme.MaterialComponents.Light.NoActionBar"
+            app:theme="@style/ThemeOverlay.MaterialComponents.ActionBar" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>
+

--- a/samples/orbit-posts/src/test/kotlin/org/orbitmvi/orbit/sample/posts/data/posts/network/PostNetworkDataSourceTest.kt
+++ b/samples/orbit-posts/src/test/kotlin/org/orbitmvi/orbit/sample/posts/data/posts/network/PostNetworkDataSourceTest.kt
@@ -20,6 +20,7 @@
 
 package org.orbitmvi.orbit.sample.posts.data.posts.network
 
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -31,7 +32,6 @@ import retrofit2.Retrofit
 import retrofit2.mock.BehaviorDelegate
 import retrofit2.mock.MockRetrofit
 import retrofit2.mock.NetworkBehavior
-import java.util.concurrent.TimeUnit
 
 class PostNetworkDataSourceTest {
     private lateinit var behavior: NetworkBehavior
@@ -163,20 +163,12 @@ class PostNetworkDataSourceTest {
             return delegate.returningResponse(posts).posts()
         }
 
-        override suspend fun user(id: Int): UserData {
-            TODO("Not yet implemented")
-        }
-
         override suspend fun users(): List<UserData> {
             return delegate.returningResponse(users).users()
         }
 
         override suspend fun comments(): List<CommentData> {
             return delegate.returningResponse(comments).comments()
-        }
-
-        override suspend fun comments(postId: Int): List<CommentData> {
-            TODO("Not yet implemented")
         }
     }
 }


### PR DESCRIPTION
Toolbar has moved inside the fragments so we can still use a coordinator layout but don't need to wrap the fragment in a NestedScrollView that was forcing every item of the RecyclerView to inflate causing performance issues.

Fixes #85 