### PR TITLE
Updates Android-ViewModel to remove stateViewModel

### DIFF
--- a/website/docs/Android-ViewModel/overview.md
+++ b/website/docs/Android-ViewModel/overview.md
@@ -71,7 +71,7 @@ val viewModelModule = module {
 }
 
 // Inject as a stateViewModel in your Activity or Fragment
-private val viewModel by stateViewModel<TodoViewModel>()
+private val viewModel by viewModel<TodoViewModel>()
 
 // Pass the SavedStateHandle to  your ViewModel
 class ExampleViewModel(savedStateHandle: SavedStateHandle) : ContainerHost<ExampleState, Nothing>, ViewModel() {


### PR DESCRIPTION
Replaces the use of deprecated stateViewModel with viewModel, According to Koin's docs:

> getStateViewModel will be merged to viewModel - no need anymore of state parameter