### PR TITLE
Support Apple Silicon simulators

### DIFF
--- a/orbit-core/orbit-core_build.gradle.kts
+++ b/orbit-core/orbit-core_build.gradle.kts
@@ -30,6 +30,7 @@ apply<AtomicFUGradlePlugin>()
 kotlin {
     jvm()
     ios()
+    iosSimulatorArm64()
     sourceSets {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")
@@ -68,5 +69,13 @@ kotlin {
         @Suppress("UnusedPrivateMember")
         val iosTest by getting {
         }
+        @Suppress("UnusedPrivateMember")
+        val iosSimulatorArm64Main by getting {
+        }
+        @Suppress("UnusedPrivateMember")
+        val iosSimulatorArm64Test by getting {
+        }
+        iosSimulatorArm64Main.dependsOn(iosMain)
+        iosSimulatorArm64Test.dependsOn(iosTest)
     }
 }

--- a/orbit-core/orbit-core_build.gradle.kts
+++ b/orbit-core/orbit-core_build.gradle.kts
@@ -62,17 +62,12 @@ kotlin {
             }
         }
 
-        @Suppress("UnusedPrivateMember")
         val iosMain by getting {
         }
-
-        @Suppress("UnusedPrivateMember")
         val iosTest by getting {
         }
-        @Suppress("UnusedPrivateMember")
         val iosSimulatorArm64Main by getting {
         }
-        @Suppress("UnusedPrivateMember")
         val iosSimulatorArm64Test by getting {
         }
         iosSimulatorArm64Main.dependsOn(iosMain)

--- a/orbit-test/orbit-test_build.gradle.kts
+++ b/orbit-test/orbit-test_build.gradle.kts
@@ -30,6 +30,7 @@ apply<AtomicFUGradlePlugin>()
 kotlin {
     jvm()
     ios()
+    iosSimulatorArm64()
     sourceSets {
         commonMain {
             dependencies {
@@ -47,17 +48,21 @@ kotlin {
             }
         }
 
-        @Suppress("UnusedPrivateMember")
         val iosMain by getting {
             dependencies {
                 implementation(ProjectDependencies.kotlinCoroutines)
             }
         }
 
-        @Suppress("UnusedPrivateMember")
         val iosTest by getting {
         }
-
+        val iosSimulatorArm64Main by getting {
+        }
+        val iosSimulatorArm64Test by getting {
+        }
+        iosSimulatorArm64Main.dependsOn(iosMain)
+        iosSimulatorArm64Test.dependsOn(iosTest)
+        
         @Suppress("UnusedPrivateMember")
         val jvmMain by getting {
             dependencies {

--- a/orbit-test/orbit-test_build.gradle.kts
+++ b/orbit-test/orbit-test_build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
         }
         iosSimulatorArm64Main.dependsOn(iosMain)
         iosSimulatorArm64Test.dependsOn(iosTest)
-        
+
         @Suppress("UnusedPrivateMember")
         val jvmMain by getting {
             dependencies {

--- a/test-common/test-common_build.gradle.kts
+++ b/test-common/test-common_build.gradle.kts
@@ -26,6 +26,7 @@ apply<kotlinx.atomicfu.plugin.gradle.AtomicFUGradlePlugin>()
 kotlin {
     jvm()
     ios()
+    iosSimulatorArm64()
     sourceSets {
         commonMain {
             dependencies {
@@ -43,8 +44,10 @@ kotlin {
             }
         }
 
-        @Suppress("UnusedPrivateMember")
         val iosMain by getting {
         }
+        val iosSimulatorArm64Main by getting {
+        }
+        iosSimulatorArm64Main.dependsOn(iosMain)
     }
 }


### PR DESCRIPTION
Based on #97, just fixed detekt

See https://kotlinlang.org/docs/mpp-share-on-platforms.html#target-shortcuts-and-arm64-apple-silicon-simulators for details.

This is needed so projects using Orbit can run on the iOS Simulators on Apple Silicon (M1) Macs.