### PR TITLE
Fix repeatOnSubscription in tests

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/AlwaysSubscribedCounter.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/AlwaysSubscribedCounter.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit.internal
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.orbitmvi.orbit.internal.repeatonsubscription.SubscribedCounter
+import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription
+
+internal object AlwaysSubscribedCounter : SubscribedCounter {
+    override val subscribed: Flow<Subscription> = flowOf(Subscription.Subscribed)
+
+    override suspend fun increment() = Unit
+
+    override suspend fun decrement() = Unit
+}

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2022 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -20,7 +20,6 @@
 
 package org.orbitmvi.orbit.internal
 
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -42,6 +41,7 @@ import org.orbitmvi.orbit.internal.repeatonsubscription.DelayingSubscribedCounte
 import org.orbitmvi.orbit.internal.repeatonsubscription.SubscribedCounter
 import org.orbitmvi.orbit.internal.repeatonsubscription.refCount
 import org.orbitmvi.orbit.syntax.ContainerContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 public class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
     initialState: STATE,

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -21,8 +21,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerDecorator
+import org.orbitmvi.orbit.internal.repeatonsubscription.SubscribedCounter
+import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription
 import org.orbitmvi.orbit.syntax.ContainerContext
 
 public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
@@ -55,7 +58,8 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
         val testDelegate = RealContainer<STATE, SIDE_EFFECT>(
             initialState = initialState,
             parentScope = parentScope,
-            settings = strategy.settings
+            settings = strategy.settings,
+            subscribedCounterOverride = AlwaysSubscribedCounter
         ).let {
             if (strategy is TestingStrategy.Suspending) {
                 InterceptingContainerDecorator(it)
@@ -73,4 +77,12 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
             throw IllegalStateException("Can only call test() once")
         }
     }
+}
+
+private object AlwaysSubscribedCounter: SubscribedCounter {
+    override val subscribed: Flow<Subscription> = flowOf(Subscription.Subscribed)
+
+    override suspend fun increment() = Unit
+
+    override suspend fun decrement() = Unit
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2022 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flowOf
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerDecorator
-import org.orbitmvi.orbit.internal.repeatonsubscription.SubscribedCounter
-import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription
 import org.orbitmvi.orbit.syntax.ContainerContext
 
 public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
@@ -77,12 +74,4 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
             throw IllegalStateException("Can only call test() once")
         }
     }
-}
-
-private object AlwaysSubscribedCounter : SubscribedCounter {
-    override val subscribed: Flow<Subscription> = flowOf(Subscription.Subscribed)
-
-    override suspend fun increment() = Unit
-
-    override suspend fun decrement() = Unit
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -79,7 +79,7 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     }
 }
 
-private object AlwaysSubscribedCounter: SubscribedCounter {
+private object AlwaysSubscribedCounter : SubscribedCounter {
     override val subscribed: Flow<Subscription> = flowOf(Subscription.Subscribed)
 
     override suspend fun increment() = Unit

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestFlowObserver.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestFlowObserver.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 /**

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/RepeatOnSubscriptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/RepeatOnSubscriptionTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2020 Babylon Partners Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * File modified by Mikołaj Leszczyński & Appmattus Limited
+ * See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
+ */
+
+package org.orbitmvi.orbit
+
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.withTimeout
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.syntax.simple.repeatOnSubscription
+
+@ExperimentalCoroutinesApi
+internal class RepeatOnSubscriptionTest {
+    private val initialState = State()
+    private val scope by lazy { CoroutineScope(Job()) }
+
+    @AfterTest
+    fun afterTest() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `test does not hang when using repeatOnSubscription`() = runBlocking {
+        val testSubject = TestMiddleware().test(initialState = initialState, settings = Container.Settings())
+
+        withTimeout(1000L) {
+            testSubject.testIntent {
+                callOnSubscription { 42 }
+            }
+        }
+
+        testSubject.assert(initialState) {
+            states(
+                { State(42) }
+            )
+        }
+    }
+
+    private inner class TestMiddleware : ContainerHost<State, Nothing> {
+        override val container = scope.container<State, Nothing>(initialState)
+
+        fun callOnSubscription(externalCall: suspend () -> Int) = intent {
+            repeatOnSubscription {
+                val result = externalCall()
+                reduce { State(result) }
+            }
+        }
+    }
+
+    private data class State(val count: Int = Random.nextInt())
+}

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/RepeatOnSubscriptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/RepeatOnSubscriptionTest.kt
@@ -20,9 +20,6 @@
 
 package org.orbitmvi.orbit
 
-import kotlin.random.Random
-import kotlin.test.AfterTest
-import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -31,6 +28,9 @@ import kotlinx.coroutines.withTimeout
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.syntax.simple.repeatOnSubscription
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
 internal class RepeatOnSubscriptionTest {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/RepeatOnSubscriptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/RepeatOnSubscriptionTest.kt
@@ -1,6 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
- * Copyright 2020 Babylon Partners Limited
+ * Copyright 2022 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * File modified by Mikołaj Leszczyński & Appmattus Limited
- * See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
  */
 
 package org.orbitmvi.orbit


### PR DESCRIPTION
Fixes #102.

`repeatOnSubscription` collects a flow of `subscribed/unsubscribed` events infinitely. This is a problem in suspending tests, as we want the block to complete if it doesn't contain any infinite flow collection.

The solution is to replace the `subscribed` flow with a cold finite flow of `Subscription.Subscribed` - This will mean that in tests the block always executes.