### PR TITLE
Allow omitting initial state in tests

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
@@ -42,6 +42,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
 ): Container<STATE, SIDE_EFFECT> =
     if (onCreate == null) {
         TestContainerDecorator(
+            initialState,
             parentScope = this,
             RealContainer(
                 initialState = initialState,
@@ -51,6 +52,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
         )
     } else {
         TestContainerDecorator(
+            initialState,
             parentScope = this,
             LazyCreateContainerDecorator(
                 RealContainer(

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -26,6 +26,7 @@ import org.orbitmvi.orbit.ContainerDecorator
 import org.orbitmvi.orbit.syntax.ContainerContext
 
 public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
+    public val originalInitialState: STATE,
     private val parentScope: CoroutineScope,
     override val actual: Container<STATE, SIDE_EFFECT>
 ) : ContainerDecorator<STATE, SIDE_EFFECT> {
@@ -49,11 +50,11 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     }
 
     public fun test(
-        initialState: STATE,
+        initialState: STATE? = null,
         strategy: TestingStrategy
     ) {
         val testDelegate = RealContainer<STATE, SIDE_EFFECT>(
-            initialState = initialState,
+            initialState = initialState ?: originalInitialState,
             parentScope = parentScope,
             settings = strategy.settings,
             subscribedCounterOverride = AlwaysSubscribedCounter

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
@@ -33,42 +33,43 @@ import org.orbitmvi.orbit.internal.TestingStrategy
  *  actually execute. This allows you to test your intents in isolation, disabling loopbacks
  *  that might make your tests too complex.
  *
- * @param initialState The state to initialize the test container with
+ * @param initialState The state to initialize the test container with. Omit this parameter to use the real initial state of the container.
  * @param isolateFlow Whether the intent should be isolated
  * @param settings Replaces the [Container.Settings] for this test
  * @return A suspending test wrapper around [ContainerHost].
  */
 public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.test(
-    initialState: STATE,
+    initialState: STATE? = null,
     isolateFlow: Boolean = true,
     settings: Container.Settings = container.settings
 ): SuspendingTestContainerHost<STATE, SIDE_EFFECT, CONTAINER_HOST> {
-    container.findTestContainer().test(
+    return container.findTestContainer().test(
         initialState = initialState,
         strategy = TestingStrategy.Suspending(settings)
-    )
-
-    return SuspendingTestContainerHost(this, initialState, isolateFlow)
+    ).let {
+        SuspendingTestContainerHost(this, initialState, isolateFlow)
+    }
 }
 
 /**
  *  Puts your [ContainerHost] into live test mode. This mode uses a real Orbit container with
  *  some basic test settings.
  *
- * @param initialState The state to initialize the test container with
+ * @param initialState The state to initialize the test container with. Omit this parameter to use the real initial state of the container.
  * @param settings Replaces the [Container.Settings] for this test
  * @return A live test wrapper around [ContainerHost].
  */
 public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.liveTest(
-    initialState: STATE,
+    initialState: STATE? = null,
     settings: Container.Settings = container.settings.copy(intentDispatcher = Dispatchers.Unconfined)
 ): RegularTestContainerHost<STATE, SIDE_EFFECT, CONTAINER_HOST> {
-    container.findTestContainer().test(
+    return container.findTestContainer().test(
         initialState = initialState,
         strategy = TestingStrategy.Live(settings)
     )
-
-    return RegularTestContainerHost(this, initialState)
+        .let {
+            RegularTestContainerHost(this, initialState)
+        }
 }
 
 internal fun <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.findTestContainer(): TestContainerDecorator<STATE, SIDE_EFFECT> {

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
@@ -75,7 +75,7 @@ public sealed class TestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAINER_
 
 public class SuspendingTestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>>(
     private val actual: CONTAINER_HOST,
-    private val initialState: STATE,
+    private val initialState: STATE?,
     private val isolateFlow: Boolean,
 ) : TestContainerHost<STATE, SIDE_EFFECT, CONTAINER_HOST>(actual) {
 
@@ -89,7 +89,8 @@ public class SuspendingTestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAIN
         if (!onCreateAllowed.compareAndSet(expect = true, update = false)) {
             throw IllegalStateException("runOnCreate should only be invoked once and before any testIntent call")
         }
-        actual.container.findOnCreate().invoke(initialState)
+        val testContainer = actual.container.findTestContainer()
+        actual.container.findOnCreate().invoke(initialState ?: testContainer.originalInitialState)
         actual.suspendingIntent(shouldIsolateFlow = false) {}
         return this
     }
@@ -133,7 +134,7 @@ public class SuspendingTestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAIN
 
 public class RegularTestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>>(
     private val actual: CONTAINER_HOST,
-    private val initialState: STATE,
+    private val initialState: STATE?,
 ) : TestContainerHost<STATE, SIDE_EFFECT, CONTAINER_HOST>(actual) {
 
     private val onCreateAllowed = atomic(true)
@@ -146,7 +147,9 @@ public class RegularTestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAINER_
         if (!onCreateAllowed.compareAndSet(expect = true, update = false)) {
             throw IllegalStateException("runOnCreate should only be invoked once and before any testIntent call")
         }
-        actual.container.findOnCreate().invoke(initialState)
+
+        val testContainer = actual.container.findTestContainer()
+        actual.container.findOnCreate().invoke(initialState ?: testContainer.originalInitialState)
         return this
     }
 

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
@@ -16,8 +16,6 @@
 
 package org.orbitmvi.orbit
 
-import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.test.assertEquals
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -25,6 +23,8 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.internal.LazyCreateContainerDecorator
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.assertEquals
 
 public sealed class TestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>>(
     actual: CONTAINER_HOST

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
@@ -16,6 +16,8 @@
 
 package org.orbitmvi.orbit
 
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.assertEquals
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -23,8 +25,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.internal.LazyCreateContainerDecorator
-import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.test.assertEquals
 
 public sealed class TestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>>(
     actual: CONTAINER_HOST
@@ -89,8 +89,7 @@ public class SuspendingTestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAIN
         if (!onCreateAllowed.compareAndSet(expect = true, update = false)) {
             throw IllegalStateException("runOnCreate should only be invoked once and before any testIntent call")
         }
-        val testContainer = actual.container.findTestContainer()
-        actual.container.findOnCreate().invoke(initialState ?: testContainer.originalInitialState)
+        actual.container.findOnCreate().invoke(initialState ?: actual.container.findTestContainer().originalInitialState)
         actual.suspendingIntent(shouldIsolateFlow = false) {}
         return this
     }
@@ -148,8 +147,7 @@ public class RegularTestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAINER_
             throw IllegalStateException("runOnCreate should only be invoked once and before any testIntent call")
         }
 
-        val testContainer = actual.container.findTestContainer()
-        actual.container.findOnCreate().invoke(initialState ?: testContainer.originalInitialState)
+        actual.container.findOnCreate().invoke(initialState ?: actual.container.findTestContainer().originalInitialState)
         return this
     }
 

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/GeneralTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/GeneralTest.kt
@@ -29,11 +29,12 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
 internal class GeneralTest {
-    private val initialState = State()
+    private val initialState = State(Random.nextInt())
     private val scope by lazy { CoroutineScope(Job()) }
 
     @AfterTest
@@ -95,6 +96,16 @@ internal class GeneralTest {
 
         assertEquals(true, (testSubject.dependency as FakeDependency).something1Called.value)
         assertEquals(false, testSubject.dependency.something2Called.value)
+    }
+
+    @Test
+    fun `initial state can be omitted from test`() = runBlocking {
+
+        val testSubject = GeneralTestMiddleware()
+        val testContainerHost = testSubject.test()
+
+        assertContentEquals(listOf(initialState), testContainerHost.stateObserver.values)
+        testContainerHost.assert(initialState)
     }
 
     private inner class GeneralTestMiddleware(val dependency: BogusDependency = FakeDependency()) :

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/GeneralTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/GeneralTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/website/docs/Test/overview.md
+++ b/website/docs/Test/overview.md
@@ -55,8 +55,9 @@ particular testing need.
 
 First we need to put our
 [ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
-into test mode and call our intent (method) under test. Let's assume we've made
-a `ViewModel` the host.
+into test mode. We pass in the initial state to seed the container with (or omit
+it entirely to use the initial state from the real container). Next, we call our
+intent method under test. Let's assume we've made a `ViewModel` the host.
 
 ```kotlin
 data class State(val count: Int = 0)


### PR DESCRIPTION
Fixes #103 . 

Passing no initial state to `test()` method is now allowed. In that case, the real initial state is used.