### PR TITLE
Fix example code error

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ fun CalculatorScreen(viewModel: CalculatorViewModel) {
 
     val state = viewModel.collectAsState().value
 
-    viewModel.collectSideEffect { handleSideEffect(navController, it) }
+    viewModel.collectSideEffect { handleSideEffect(it) }
 
     // render UI using data from 'state'
     ...


### PR DESCRIPTION
In the Jetpack Compose example code in the README, `navController` is used for the `handleSideEffect` function argument, but the `navController` argument does not exist in the `handleSideEffect` function implementation. I think this should be fixed as it can be confusing.

Now:
```kotlin
@Composable
fun CalculatorScreen(viewModel: CalculatorViewModel) {

    val state = viewModel.collectAsState().value

    viewModel.collectSideEffect { handleSideEffect(navController, it) }

    // render UI using data from 'state'
    ...
}

private fun handleSideEffect(sideEffect: CalculatorSideEffect) {
    when (sideEffect) {
        is CalculatorSideEffect.Toast -> toast(sideEffect.text)
    }
}
```

Should edited:
```kotlin
@Composable
fun CalculatorScreen(viewModel: CalculatorViewModel) {

    val state = viewModel.collectAsState().value

    viewModel.collectSideEffect { handleSideEffect(it) } // removed navController argument

    // render UI using data from 'state'
    ...
}

private fun handleSideEffect(sideEffect: CalculatorSideEffect) {
    when (sideEffect) {
        is CalculatorSideEffect.Toast -> toast(sideEffect.text)
    }
}
```