### PR TITLE
Implement debugMode to verify `container` uses a backing field

### DIFF
--- a/orbit-compose/src/main/kotlin/org/orbitmvi/orbit/compose/ContainerHostExtensions.kt
+++ b/orbit-compose/src/main/kotlin/org/orbitmvi/orbit/compose/ContainerHostExtensions.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.debugModeContainerHostVerification
 
 /**
  * Observe [Container.sideEffectFlow] in a Compose [LaunchedEffect].
@@ -39,6 +40,8 @@ public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.co
     lifecycleState: Lifecycle.State = Lifecycle.State.STARTED,
     sideEffect: (suspend (sideEffect: SIDE_EFFECT) -> Unit)
 ) {
+    debugModeContainerHostVerification()
+
     val sideEffectFlow = container.sideEffectFlow
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -59,6 +62,8 @@ public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.co
     lifecycleState: Lifecycle.State = Lifecycle.State.STARTED,
     state: (suspend (state: STATE) -> Unit)
 ) {
+    debugModeContainerHostVerification()
+
     val stateFlow = container.stateFlow
     val lifecycleOwner = LocalLifecycleOwner.current
 
@@ -77,6 +82,8 @@ public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.co
 public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.collectAsState(
     lifecycleState: Lifecycle.State = Lifecycle.State.STARTED
 ): State<STATE> {
+    debugModeContainerHostVerification()
+
     val stateFlow = container.stateFlow
     val lifecycleOwner = LocalLifecycleOwner.current
 

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,6 +86,7 @@ public interface Container<STATE : Any, SIDE_EFFECT : Any> {
         public val idlingRegistry: IdlingResource = NoopIdlingResource(),
         public val intentDispatcher: CoroutineDispatcher = Dispatchers.Default,
         public val exceptionHandler: CoroutineExceptionHandler? = null,
-        public val repeatOnSubscribedStopTimeout: Long = 100L
+        public val repeatOnSubscribedStopTimeout: Long = 100L,
+        public val debugMode: Boolean = false
     )
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleSyntaxExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleSyntaxExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,6 +69,8 @@ public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.in
     transformer: suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit
 ): Unit =
     runBlocking {
+        debugModeContainerHostVerification()
+
         container.orbit {
             withIdling(registerIdling) {
                 SimpleSyntax(this).transformer()
@@ -86,6 +88,15 @@ public suspend fun <S : Any, SE : Any> SimpleSyntax<S, SE>.repeatOnSubscription(
             containerContext.subscribedCounter.subscribed.mapLatest {
                 if (it.isSubscribed) block() else null
             }.collect()
+        }
+    }
+}
+
+public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.debugModeContainerHostVerification() {
+    if (container.settings.debugMode) {
+        //
+        if (container != container) {
+            throw IllegalStateException("container should use a backing field")
         }
     }
 }

--- a/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/ContainerHostExtensions.kt
+++ b/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/ContainerHostExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.debugModeContainerHostVerification
 
 /**
  * Observe [Container.stateFlow] and [Container.sideEffectFlow] correctly on Android in one-line of code.
@@ -46,6 +47,8 @@ fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.observe(
     state: (suspend (state: STATE) -> Unit)? = null,
     sideEffect: (suspend (sideEffect: SIDE_EFFECT) -> Unit)? = null
 ) {
+    debugModeContainerHostVerification()
+
     lifecycleOwner.lifecycleScope.launch {
         // See https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda
         lifecycleOwner.lifecycle.repeatOnLifecycle(lifecycleState) {

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/viewmodel/PostDetailsViewModel.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/viewmodel/PostDetailsViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,12 +22,14 @@ package org.orbitmvi.orbit.sample.posts.app.features.postdetails.viewmodel
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.sample.posts.domain.repositories.PostOverview
 import org.orbitmvi.orbit.sample.posts.domain.repositories.PostRepository
 import org.orbitmvi.orbit.sample.posts.domain.repositories.Status
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.BuildConfig
 import org.orbitmvi.orbit.viewmodel.container
 
 class PostDetailsViewModel(
@@ -36,7 +38,11 @@ class PostDetailsViewModel(
     private val postOverview: PostOverview
 ) : ViewModel(), ContainerHost<PostDetailState, Nothing> {
 
-    override val container = container<PostDetailState, Nothing>(PostDetailState.NoDetailsAvailable(postOverview), savedStateHandle) {
+    override val container = container<PostDetailState, Nothing>(
+        initialState = PostDetailState.NoDetailsAvailable(postOverview),
+        savedStateHandle = savedStateHandle,
+        settings = Container.Settings(debugMode = BuildConfig.DEBUG)
+    ) {
         if (it !is PostDetailState.Details) {
             loadDetails()
         }

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,6 +32,7 @@ import org.orbitmvi.orbit.sample.posts.domain.repositories.PostRepository
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.BuildConfig
 import org.orbitmvi.orbit.viewmodel.container
 
 class PostListViewModel(
@@ -45,7 +46,7 @@ class PostListViewModel(
     override val container = container<PostListState, NavigationEvent>(
         initialState = PostListState(),
         savedStateHandle = savedStateHandle,
-        settings = Container.Settings(exceptionHandler = exceptionHandler)
+        settings = Container.Settings(exceptionHandler = exceptionHandler, debugMode = BuildConfig.DEBUG)
     ) {
         if (it.overviews.isEmpty()) {
             loadOverviews()


### PR DESCRIPTION
Fixes #117

So the checks aren't duplicated I've had to make `debugModeContainerHostVerification` public.

This PR only introduces a guardrail for ensuring `container` uses a backing field