### PR TITLE
Fix kotlin-test-junit implementation

### DIFF
--- a/orbit-compose/orbit-compose_build.gradle.kts
+++ b/orbit-compose/orbit-compose_build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     implementation(libs.androidxComposeUi)
 
     // Testing
-    implementation(kotlin("test-junit"))
+    testImplementation(kotlin("test-junit"))
     testImplementation(project(":orbit-test"))
     testImplementation(project(":test-common"))
     testImplementation(libs.androidxEspressoCore)


### PR DESCRIPTION
Change orbit-compose_build.gradle.kts implementation(kotlin("test-junit")) to testImplementation(kotlin("test-junit"))

Gradle will print an error when the kotlin version of my project is inconsistent with orbit-mvi. 
`Cannot find a version of 'org.jetbrains.kotlin:kotlin-test' that satisfies the version constraints`

