### PR TITLE
Add intent jobs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ desugar = "2.0.2"
 jacoco = "0.8.8"
 junit4 = "4.13.2"
 robolectric = "4.9.2"
-turbine = "0.12.1"
+turbine = "0.12.3"
 
 
 [libraries]

--- a/orbit-core/orbit-core_build.gradle.kts
+++ b/orbit-core/orbit-core_build.gradle.kts
@@ -48,6 +48,7 @@ kotlin {
                 implementation(project(":test-common"))
                 implementation(project(":orbit-test"))
                 implementation(libs.kotlinCoroutines)
+                implementation(libs.kotlinCoroutinesTest)
             }
         }
 

--- a/orbit-core/orbit-core_build.gradle.kts
+++ b/orbit-core/orbit-core_build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
                 implementation(project(":orbit-test"))
                 implementation(libs.kotlinCoroutines)
                 implementation(libs.kotlinCoroutinesTest)
+                implementation(libs.turbine)
             }
         }
 

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
@@ -23,6 +23,7 @@ package org.orbitmvi.orbit
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -69,7 +70,7 @@ public interface Container<STATE : Any, SIDE_EFFECT : Any> {
      *
      * @param orbitIntent lambda returning the suspend function representing the intent
      */
-    public suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit)
+    public suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit): Job
 
     /**
      * Executes an orbit intent inline, circumventing orbit's dispatching. The intents are built in the [ContainerHost] using your chosen syntax.
@@ -78,6 +79,18 @@ public interface Container<STATE : Any, SIDE_EFFECT : Any> {
      */
     @OrbitExperimental
     public suspend fun inlineOrbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit)
+
+    /**
+     * Cancels the container scope and all intents in progress.
+     */
+    @OrbitExperimental
+    public fun cancel()
+
+    /**
+     * Joins all in progress intents in the container. This suspends until all intents have completed.
+     */
+    @OrbitExperimental
+    public suspend fun joinIntents()
 
     /**
      * Represents additional settings to create the container with.

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
@@ -20,16 +20,10 @@
 
 package org.orbitmvi.orbit
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import org.orbitmvi.orbit.annotation.OrbitExperimental
-import org.orbitmvi.orbit.idling.IdlingResource
-import org.orbitmvi.orbit.idling.NoopIdlingResource
 import org.orbitmvi.orbit.syntax.ContainerContext
 
 /**
@@ -55,7 +49,7 @@ public interface Container<STATE : Any, SIDE_EFFECT : Any> {
 
     /**
      * A [Flow] of one-off side effects posted from [Container]. Caches side effects when there are no collectors.
-     * The size of the cache can be controlled via Container [Settings] and determines if and when the orbit thread suspends when you
+     * The size of the cache can be controlled via [SettingsBuilder] and determines if and when the orbit thread suspends when you
      * post a side effect. The default is unlimited. You don't have to touch this unless you are posting many side effects which could result in
      * `OutOfMemoryError`.
      *
@@ -91,24 +85,4 @@ public interface Container<STATE : Any, SIDE_EFFECT : Any> {
      */
     @OrbitExperimental
     public suspend fun joinIntents()
-
-    /**
-     * Represents additional settings to create the container with.
-     *
-     * @property sideEffectBufferSize Defines how many side effects can be buffered before the container suspends. If you are
-     * sending many side effects and getting out of memory exceptions this can be turned down to suspend the container instead.
-     * Unlimited by default.
-     * @property idlingRegistry The registry used by the container for signalling idling for UI tests
-     * @property intentDispatcher The dispatcher used for handling incoming [orbit] intents
-     * @property repeatOnSubscribedStopTimeout A delay (in milliseconds) between the disappearance of the last subscriber and
-     * the stopping of the repeatOnSubscribed block
-     */
-    @Deprecated("Use the builder function in [container] or [test/liveTest]")
-    public data class Settings(
-        public val sideEffectBufferSize: Int = Channel.UNLIMITED,
-        public val idlingRegistry: IdlingResource = NoopIdlingResource(),
-        public val intentDispatcher: CoroutineDispatcher = Dispatchers.Default,
-        public val exceptionHandler: CoroutineExceptionHandler? = null,
-        public val repeatOnSubscribedStopTimeout: Long = 100L
-    )
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerDecorator.kt
@@ -20,6 +20,7 @@
 
 package org.orbitmvi.orbit
 
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import org.orbitmvi.orbit.annotation.OrbitExperimental
@@ -45,12 +46,22 @@ public interface ContainerDecorator<STATE : Any, SIDE_EFFECT : Any> : Container<
     override val sideEffectFlow: Flow<SIDE_EFFECT>
         get() = actual.sideEffectFlow
 
-    override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit) {
-        actual.orbit(orbitIntent)
+    override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit): Job {
+        return actual.orbit(orbitIntent)
     }
 
     @OptIn(OrbitExperimental::class)
     override suspend fun inlineOrbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit) {
         actual.inlineOrbit(orbitIntent)
+    }
+
+    @OptIn(OrbitExperimental::class)
+    override suspend fun joinIntents() {
+        actual.joinIntents()
+    }
+
+    @OptIn(OrbitExperimental::class)
+    override fun cancel() {
+        actual.cancel()
     }
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
@@ -27,6 +27,7 @@ import org.orbitmvi.orbit.Container.Settings
 import org.orbitmvi.orbit.internal.LazyCreateContainerDecorator
 import org.orbitmvi.orbit.internal.RealContainer
 import org.orbitmvi.orbit.internal.TestContainerDecorator
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
 
 /**
  * Helps create a concrete container in a standard way.
@@ -41,7 +42,7 @@ import org.orbitmvi.orbit.internal.TestContainerDecorator
 public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
     initialState: STATE,
     settings: Settings,
-    onCreate: ((state: STATE) -> Unit)? = null
+    onCreate: (suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit)? = null
 ): Container<STATE, SIDE_EFFECT> =
     if (onCreate == null) {
         TestContainerDecorator(
@@ -63,8 +64,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
                     settings = settings.toRealSettings(),
                     parentScope = this
                 ),
-                onCreate
-            )
+            ) { SimpleSyntax(this).onCreate() }
         )
     }
 
@@ -80,7 +80,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
 public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
     initialState: STATE,
     buildSettings: SettingsBuilder.() -> Unit = {},
-    onCreate: ((state: STATE) -> Unit)? = null
+    onCreate: (suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit)? = null
 ): Container<STATE, SIDE_EFFECT> =
     if (onCreate == null) {
         TestContainerDecorator(
@@ -101,8 +101,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
                     initialState = initialState,
                     settings = SettingsBuilder().apply { buildSettings() }.settings,
                     parentScope = this
-                ),
-                onCreate
-            )
+                )
+            ) { SimpleSyntax(this).onCreate() }
         )
     }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
@@ -18,55 +18,13 @@
  * See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
  */
 
-@file:Suppress("DEPRECATION")
-
 package org.orbitmvi.orbit
 
 import kotlinx.coroutines.CoroutineScope
-import org.orbitmvi.orbit.Container.Settings
 import org.orbitmvi.orbit.internal.LazyCreateContainerDecorator
 import org.orbitmvi.orbit.internal.RealContainer
 import org.orbitmvi.orbit.internal.TestContainerDecorator
 import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
-
-/**
- * Helps create a concrete container in a standard way.
- *
- * @param initialState The initial state of the container.
- * @param settings The [Settings] to set the container up with.
- * @param onCreate The lambda to execute when the container is created. By default it is
- * executed in a lazy manner when the container is first interacted with in any way.
- * @return A [Container] implementation
- */
-@Deprecated(message = "Use overload with settings builder instead. This will be removed in the future.")
-public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
-    initialState: STATE,
-    settings: Settings,
-    onCreate: (suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit)? = null
-): Container<STATE, SIDE_EFFECT> =
-    if (onCreate == null) {
-        TestContainerDecorator(
-            initialState,
-            parentScope = this,
-            RealContainer(
-                initialState = initialState,
-                settings = settings.toRealSettings(),
-                parentScope = this
-            )
-        )
-    } else {
-        TestContainerDecorator(
-            initialState,
-            parentScope = this,
-            LazyCreateContainerDecorator(
-                RealContainer(
-                    initialState = initialState,
-                    settings = settings.toRealSettings(),
-                    parentScope = this
-                ),
-            ) { SimpleSyntax(this).onCreate() }
-        )
-    }
 
 /**
  * Helps create a concrete container in a standard way.

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
@@ -38,13 +38,3 @@ public class SettingsBuilder {
             settings = settings.copy(repeatOnSubscribedStopTimeout = value)
         }
 }
-
-@Suppress("DEPRECATION")
-internal fun Container.Settings.toRealSettings() = RealSettings(
-    sideEffectBufferSize = sideEffectBufferSize,
-    idlingRegistry = idlingRegistry,
-    eventLoopDispatcher = intentDispatcher,
-    intentLaunchingDispatcher = intentDispatcher,
-    exceptionHandler = exceptionHandler,
-    repeatOnSubscribedStopTimeout = repeatOnSubscribedStopTimeout
-)

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/idling/NoopIdlingResource.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/idling/NoopIdlingResource.kt
@@ -20,7 +20,7 @@
 
 package org.orbitmvi.orbit.idling
 
-internal class NoopIdlingResource : IdlingResource {
+public class NoopIdlingResource : IdlingResource {
     override fun increment(): Unit = Unit
     override fun decrement(): Unit = Unit
     override fun close(): Unit = Unit

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/InterceptingContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/InterceptingContainerDecorator.kt
@@ -16,6 +16,7 @@
 
 package org.orbitmvi.orbit.internal
 
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import org.orbitmvi.orbit.ContainerDecorator
 import org.orbitmvi.orbit.syntax.ContainerContext
@@ -25,8 +26,9 @@ public class InterceptingContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
 ) : ContainerDecorator<STATE, SIDE_EFFECT> {
     public val savedIntents: Channel<suspend () -> Unit> = Channel(Channel.UNLIMITED)
 
-    override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit) {
+    override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit): Job {
         savedIntents.send { actual.pluginContext.orbitIntent() }
+        return Job()
     }
 
     override suspend fun inlineOrbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit) {

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
@@ -30,10 +30,11 @@ import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerDecorator
 import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.syntax.ContainerContext
+import org.orbitmvi.orbit.syntax.simple.intent
 
 public class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     override val actual: Container<STATE, SIDE_EFFECT>,
-    public val onCreate: (state: STATE) -> Unit
+    public val onCreate: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit
 ) : ContainerDecorator<STATE, SIDE_EFFECT> {
     private val created = atomic(false)
 
@@ -46,7 +47,7 @@ public class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
 
     private fun runOnCreate() {
         if (created.compareAndSet(expect = false, update = true)) {
-            onCreate(actual.stateFlow.value)
+            actual.intent(registerIdling = false, transformer = onCreate)
         }
     }
 

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
@@ -21,6 +21,7 @@
 package org.orbitmvi.orbit.internal
 
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emitAll
@@ -49,8 +50,8 @@ public class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
         }
     }
 
-    override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit) {
-        runOnCreate().also { actual.orbit(orbitIntent) }
+    override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit): Job {
+        runOnCreate().also { return actual.orbit(orbitIntent) }
     }
 
     @OptIn(OrbitExperimental::class)

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -70,8 +70,6 @@ public class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
 
     @OrbitExperimental
     override suspend fun joinIntents() {
-        println(intentJob)
-        println(intentJob.children.toList())
         intentJob.children.toList().joinAll()
     }
 

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -18,6 +18,7 @@ package org.orbitmvi.orbit.internal
 
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -47,8 +48,8 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     override val sideEffectFlow: Flow<SIDE_EFFECT>
         get() = delegate.value.sideEffectFlow
 
-    override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit) {
-        delegate.value.orbit(orbitIntent)
+    override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit): Job {
+        return delegate.value.orbit(orbitIntent)
     }
 
     @OptIn(OrbitExperimental::class)
@@ -82,5 +83,15 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
         if (!testDelegateSet) {
             error("Can only call test() once")
         }
+    }
+
+    @OptIn(OrbitExperimental::class)
+    public override suspend fun joinIntents() {
+        delegate.value.joinIntents()
+    }
+
+    @OptIn(OrbitExperimental::class)
+    public override fun cancel() {
+        delegate.value.cancel()
     }
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleSyntaxExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleSyntaxExtensions.kt
@@ -21,6 +21,7 @@
 package org.orbitmvi.orbit.syntax.simple
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapLatest
@@ -66,7 +67,7 @@ public suspend fun <S : Any, SE : Any> SimpleSyntax<S, SE>.postSideEffect(sideEf
 public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.intent(
     registerIdling: Boolean = true,
     transformer: suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit
-): Unit =
+): Job =
     runBlocking {
         container.orbit {
             withIdling(registerIdling) {

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
@@ -18,18 +18,19 @@
 
 package org.orbitmvi.orbit.internal
 
+import app.cash.turbine.test
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.isActive
-import org.orbitmvi.orbit.Container
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -41,6 +42,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
@@ -54,53 +56,55 @@ internal class ContainerExceptionHandlerTest {
     }
 
     @Test
-    fun `by default any exception breaks the scope`() = runBlocking {
+    fun `by default any exception breaks the scope`() = runTest {
         val initState = Random.nextInt()
         val container = scope.container<Int, Nothing>(
             initialState = initState
         )
-        val testObserver = container.stateFlow.test()
-        val newState = Random.nextInt()
+        container.stateFlow.test {
+            val newState = Random.nextInt()
 
-        container.orbit {
-            throw IllegalStateException()
-        }
-        container.orbit {
-            reduce { newState }
-        }
+            val job = container.orbit {
+                throw IllegalStateException()
+            }
+            container.orbit {
+                reduce { newState }
+            }
 
-        testObserver.awaitCount(2, 1000L)
-        assertEquals(listOf(initState), testObserver.values)
-        assertEquals(false, scope.isActive)
+            assertEquals(initState, awaitItem())
+            job.join()
+            assertEquals(false, scope.isActive)
+        }
     }
 
     @Test
-    fun `with exception handler exceptions are caught`() {
+    fun `with exception handler exceptions are caught`() = runTest {
         val initState = Random.nextInt()
         val exceptions = mutableListOf<Throwable>()
         val exceptionHandler = CoroutineExceptionHandler { _, throwable -> exceptions += throwable }
         val container = scope.container<Int, Nothing>(
             initialState = initState,
-            settings = Container.Settings(
-                exceptionHandler = exceptionHandler,
-                intentDispatcher = Dispatchers.Unconfined
-            )
+            buildSettings = {
+                this.exceptionHandler = exceptionHandler
+            }
         )
-        val newState = Random.nextInt()
 
-        runBlocking {
+        container.stateFlow.test {
+            val newState = Random.nextInt()
+
             container.orbit {
                 reduce { throw IllegalStateException() }
             }
             container.orbit {
                 reduce { newState }
             }
-        }
 
-        assertEquals(newState, container.stateFlow.value)
-        assertEquals(true, scope.isActive)
-        assertEquals(1, exceptions.size)
-        assertTrue { exceptions.first() is IllegalStateException }
+            assertEquals(initState, awaitItem())
+            assertEquals(newState, awaitItem())
+            assertEquals(true, scope.isActive)
+            assertEquals(1, exceptions.size)
+            assertTrue { exceptions.first() is IllegalStateException }
+        }
     }
 
     @Test
@@ -124,28 +128,29 @@ internal class ContainerExceptionHandlerTest {
             }
         val container = containerScope.container<Unit, Nothing>(
             initialState = Unit,
-            settings = Container.Settings(
-                exceptionHandler = exceptionHandler,
-                intentDispatcher = Dispatchers.Unconfined
-            )
+            buildSettings = {
+                this.exceptionHandler = exceptionHandler
+            }
         )
-        runBlocking {
-            val exceptions = mutableListOf<Throwable>()
-            container.orbit {
+        val exceptions = mutableListOf<Throwable>()
+        runTest {
+            val job = container.orbit {
                 try {
-                    flow {
-                        while (true) {
-                            emit(Unit)
-                            delay(1000)
-                        }
-                    }.collect()
+                    delay(Long.MAX_VALUE)
                 } catch (e: CancellationException) {
                     exceptions.add(e)
                     throw e
                 }
             }
-            containerScope.cancel()
-            scopeJob.join()
+            coroutineScope {
+                launch {
+                    runCatching {
+                        job.join()
+                    }
+                }
+                scopeJob.cancelAndJoin()
+            }
+            assertFalse { containerScope.isActive }
             assertEquals(1, exceptions.size)
         }
     }
@@ -158,10 +163,9 @@ internal class ContainerExceptionHandlerTest {
         val containerHost = object : ContainerHost<Int, Nothing> {
             override val container = scope.container<Int, Nothing>(
                 initialState = initState,
-                settings = Container.Settings(
-                    exceptionHandler = exceptionHandler,
-                    intentDispatcher = Dispatchers.Unconfined
-                )
+                buildSettings = {
+                    this.exceptionHandler = exceptionHandler
+                }
             )
         }.test(initState) {
             isolateFlow = false
@@ -195,9 +199,9 @@ internal class ContainerExceptionHandlerTest {
         val containerHost = object : ContainerHost<Int, Nothing> {
             override val container = scope.container<Int, Nothing>(
                 initialState = initState,
-                settings = Container.Settings(
-                    intentDispatcher = Dispatchers.Unconfined
-                )
+                buildSettings = {
+                    this.exceptionHandler = exceptionHandler
+                }
             )
         }.test(initState) {
             isolateFlow = false

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerLifecycleTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerLifecycleTest.kt
@@ -63,7 +63,7 @@ internal class ContainerLifecycleTest {
     private inner class Middleware(initialState: TestState) : ContainerHost<TestState, String> {
 
         override val container = scope.container<TestState, String>(initialState) {
-            onCreate(it)
+            onCreate(state)
         }
 
         private fun onCreate(createState: TestState) = intent {

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerLifecycleTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerLifecycleTest.kt
@@ -28,8 +28,8 @@ import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
-import org.orbitmvi.orbit.test
 import org.orbitmvi.orbit.test.assertContainExactly
+import org.orbitmvi.orbit.testFlowObserver
 import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -48,8 +48,8 @@ internal class ContainerLifecycleTest {
     fun `onCreate is called once after connecting to the container`() {
         val initialState = TestState()
         val middleware = Middleware(initialState)
-        val testStateObserver = middleware.container.stateFlow.test()
-        val testSideEffectObserver = middleware.container.sideEffectFlow.test()
+        val testStateObserver = middleware.container.stateFlow.testFlowObserver()
+        val testSideEffectObserver = middleware.container.sideEffectFlow.testFlowObserver()
 
         testStateObserver.awaitCount(1)
         testSideEffectObserver.awaitCount(1)

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerThreadingTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerThreadingTest.kt
@@ -29,8 +29,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.container
-import org.orbitmvi.orbit.test
 import org.orbitmvi.orbit.test.runBlocking
+import org.orbitmvi.orbit.testFlowObserver
 import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -49,7 +49,7 @@ internal class ContainerThreadingTest {
     @Test
     fun `container can process a second action while the first is suspended`() {
         val container = scope.container<Int, Nothing>(Random.nextInt())
-        val observer = container.stateFlow.test()
+        val observer = container.stateFlow.testFlowObserver()
         val newState = Random.nextInt()
 
         runBlocking {
@@ -70,7 +70,7 @@ internal class ContainerThreadingTest {
         // This scenario is meant to simulate calling only reducers from the UI thread
         runBlocking {
             val container = scope.container<TestState, Nothing>(TestState())
-            val testStateObserver = container.stateFlow.test()
+            val testStateObserver = container.stateFlow.testFlowObserver()
             val expectedStates = mutableListOf(
                 TestState(
                     emptyList()
@@ -101,7 +101,7 @@ internal class ContainerThreadingTest {
         // This scenario is meant to simulate calling only reducers from the UI thread
         runBlocking {
             val container = scope.container<TestState, Nothing>(TestState())
-            val testStateObserver = container.stateFlow.test()
+            val testStateObserver = container.stateFlow.testFlowObserver()
             val expectedStates = mutableListOf(
                 TestState(
                     emptyList()

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SideEffectTest.kt
@@ -28,9 +28,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.container
-import org.orbitmvi.orbit.test
 import org.orbitmvi.orbit.test.assertContainExactly
 import org.orbitmvi.orbit.test.assertNotContainExactly
+import org.orbitmvi.orbit.testFlowObserver
 import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -50,7 +50,7 @@ internal class SideEffectTest {
     fun `side effects are emitted in order`() = runBlocking {
         val container = scope.container<Unit, Int>(Unit)
 
-        val testSideEffectObserver1 = container.sideEffectFlow.test()
+        val testSideEffectObserver1 = container.sideEffectFlow.testFlowObserver()
 
         repeat(1000) {
             container.someFlow(it)
@@ -68,9 +68,9 @@ internal class SideEffectTest {
         val action3 = Random.nextInt()
         val container = scope.container<Unit, Int>(Unit)
 
-        val testSideEffectObserver1 = container.sideEffectFlow.test()
-        val testSideEffectObserver2 = container.sideEffectFlow.test()
-        val testSideEffectObserver3 = container.sideEffectFlow.test()
+        val testSideEffectObserver1 = container.sideEffectFlow.testFlowObserver()
+        val testSideEffectObserver2 = container.sideEffectFlow.testFlowObserver()
+        val testSideEffectObserver3 = container.sideEffectFlow.testFlowObserver()
 
         container.someFlow(action)
         container.someFlow(action2)
@@ -97,7 +97,7 @@ internal class SideEffectTest {
         container.someFlow(action2)
         container.someFlow(action3)
 
-        val testSideEffectObserver1 = container.sideEffectFlow.test()
+        val testSideEffectObserver1 = container.sideEffectFlow.testFlowObserver()
 
         testSideEffectObserver1.awaitCount(3)
 
@@ -110,7 +110,7 @@ internal class SideEffectTest {
         val action2 = Random.nextInt()
         val action3 = Random.nextInt()
         val container = scope.container<Unit, Int>(Unit)
-        val testSideEffectObserver1 = container.sideEffectFlow.test()
+        val testSideEffectObserver1 = container.sideEffectFlow.testFlowObserver()
 
         container.someFlow(action)
         container.someFlow(action2)
@@ -118,7 +118,7 @@ internal class SideEffectTest {
         testSideEffectObserver1.awaitCount(3)
         testSideEffectObserver1.close()
 
-        val testSideEffectObserver2 = container.sideEffectFlow.test()
+        val testSideEffectObserver2 = container.sideEffectFlow.testFlowObserver()
 
         testSideEffectObserver1.awaitCount(3, 10L)
 
@@ -130,7 +130,7 @@ internal class SideEffectTest {
         val action = Random.nextInt()
         val container = scope.container<Unit, Int>(Unit)
 
-        val testSideEffectObserver1 = container.sideEffectFlow.test()
+        val testSideEffectObserver1 = container.sideEffectFlow.testFlowObserver()
 
         container.someFlow(action)
 
@@ -145,7 +145,7 @@ internal class SideEffectTest {
             }
         }
 
-        val testSideEffectObserver2 = container.sideEffectFlow.test()
+        val testSideEffectObserver2 = container.sideEffectFlow.testFlowObserver()
         testSideEffectObserver2.awaitCount(1000)
 
         testSideEffectObserver1.values.assertContainExactly(action)

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/StateTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/StateTest.kt
@@ -28,8 +28,8 @@ import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
-import org.orbitmvi.orbit.test
 import org.orbitmvi.orbit.test.assertContainExactly
+import org.orbitmvi.orbit.testFlowObserver
 import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -49,7 +49,7 @@ internal class StateTest {
     fun `initial state is emitted on connection`() {
         val initialState = TestState()
         val middleware = Middleware(initialState)
-        val testStateObserver = middleware.container.stateFlow.test()
+        val testStateObserver = middleware.container.stateFlow.testFlowObserver()
 
         testStateObserver.awaitCount(1)
 
@@ -60,12 +60,12 @@ internal class StateTest {
     fun `latest state is emitted on connection`() {
         val initialState = TestState()
         val middleware = Middleware(initialState)
-        val testStateObserver = middleware.container.stateFlow.test()
+        val testStateObserver = middleware.container.stateFlow.testFlowObserver()
         val action = Random.nextInt()
         middleware.something(action)
         testStateObserver.awaitCount(2) // block until the state is updated
 
-        val testStateObserver2 = middleware.container.stateFlow.test()
+        val testStateObserver2 = middleware.container.stateFlow.testFlowObserver()
         testStateObserver2.awaitCount(1)
 
         testStateObserver.values.assertContainExactly(
@@ -92,7 +92,7 @@ internal class StateTest {
         val initialState = TestState()
         val middleware = Middleware(initialState)
         val action = Random.nextInt()
-        val testStateObserver = middleware.container.stateFlow.test()
+        val testStateObserver = middleware.container.stateFlow.testFlowObserver()
 
         middleware.something(action)
 

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/DelayingSubscribedCounterTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/DelayingSubscribedCounterTest.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription.Subscribed
 import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription.Unsubscribed
-import org.orbitmvi.orbit.test
 import org.orbitmvi.orbit.test.runBlocking
+import org.orbitmvi.orbit.testFlowObserver
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -27,7 +27,7 @@ class DelayingSubscribedCounterTest {
     fun `initial value is unsubscribed`() {
         runBlocking {
             val counter = DelayingSubscribedCounter(testScope, 0)
-            val testObserver = counter.subscribed.test()
+            val testObserver = counter.subscribed.testFlowObserver()
 
             assertEquals(listOf(Unsubscribed), testObserver.values)
         }
@@ -37,7 +37,7 @@ class DelayingSubscribedCounterTest {
     fun `incrementing subscribes`() {
         runBlocking {
             val counter = DelayingSubscribedCounter(testScope, 0)
-            val testObserver = counter.subscribed.test()
+            val testObserver = counter.subscribed.testFlowObserver()
 
             counter.increment()
 
@@ -50,7 +50,7 @@ class DelayingSubscribedCounterTest {
     fun `increment decrement unsubscribes`() {
         runBlocking {
             val counter = DelayingSubscribedCounter(testScope, 0)
-            val testObserver = counter.subscribed.test()
+            val testObserver = counter.subscribed.testFlowObserver()
 
             counter.increment()
             counter.decrement()
@@ -64,7 +64,7 @@ class DelayingSubscribedCounterTest {
     fun `values received are distinct`() {
         runBlocking {
             val counter = DelayingSubscribedCounter(testScope, 0)
-            val testObserver = counter.subscribed.test()
+            val testObserver = counter.subscribed.testFlowObserver()
 
             counter.increment()
             counter.increment()
@@ -80,7 +80,7 @@ class DelayingSubscribedCounterTest {
     fun `negative decrements are ignored`() {
         runBlocking {
             val counter = DelayingSubscribedCounter(testScope, 0)
-            val testObserver = counter.subscribed.test()
+            val testObserver = counter.subscribed.testFlowObserver()
 
             counter.decrement()
             counter.decrement()
@@ -97,7 +97,7 @@ class DelayingSubscribedCounterTest {
     fun `unsubscribed received on launch immediately`() {
         runBlocking {
             val counter = DelayingSubscribedCounter(testScope, 500)
-            val testObserver = counter.subscribed.mapTimed().test()
+            val testObserver = counter.subscribed.mapTimed().testFlowObserver()
 
             testObserver.awaitCount(1)
             assertEquals(Unsubscribed, testObserver.values.first().value)
@@ -111,9 +111,9 @@ class DelayingSubscribedCounterTest {
             val counter = DelayingSubscribedCounter(testScope, 500)
 
             // Wait to receive unsubscribed at launch
-            counter.subscribed.mapTimed().test().awaitCount(1)
+            counter.subscribed.mapTimed().testFlowObserver().awaitCount(1)
 
-            val testObserver2 = counter.subscribed.mapTimed().test()
+            val testObserver2 = counter.subscribed.mapTimed().testFlowObserver()
             testObserver2.awaitCount(1)
             assertEquals(Unsubscribed, testObserver2.values.first().value)
             assertTrue(testObserver2.values.first().time < 450)
@@ -124,7 +124,7 @@ class DelayingSubscribedCounterTest {
     fun `unsubscribed received after delay`() {
         runBlocking {
             val counter = DelayingSubscribedCounter(testScope, 500)
-            val testObserver = counter.subscribed.mapTimed().test()
+            val testObserver = counter.subscribed.mapTimed().testFlowObserver()
 
             counter.increment()
             counter.decrement()

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslThreadingTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslThreadingTest.kt
@@ -35,11 +35,11 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.container
-import org.orbitmvi.orbit.test
 import org.orbitmvi.orbit.test.IgnoreIos
 import org.orbitmvi.orbit.test.ScopedBlockingWorkSimulator
 import org.orbitmvi.orbit.test.assertContainExactly
 import org.orbitmvi.orbit.test.runBlocking
+import org.orbitmvi.orbit.testFlowObserver
 import kotlin.random.Random
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -60,7 +60,7 @@ internal class SimpleDslThreadingTest {
     @IgnoreIos
     fun `blocking intent with context switch does not block the reducer`() = runBlocking {
         val action = Random.nextInt()
-        val testFlowObserver = middleware.container.stateFlow.test()
+        val testFlowObserver = middleware.container.stateFlow.testFlowObserver()
 
         middleware.backgroundIntent()
 
@@ -77,7 +77,7 @@ internal class SimpleDslThreadingTest {
     @Test
     fun `suspending intent does not block the reducer`() = runBlocking {
         val action = Random.nextInt()
-        val testFlowObserver = middleware.container.stateFlow.test()
+        val testFlowObserver = middleware.container.stateFlow.testFlowObserver()
 
         middleware.suspendingIntent()
         withTimeout(TIMEOUT) {
@@ -93,7 +93,7 @@ internal class SimpleDslThreadingTest {
     @Test
     fun `blocking intent without context switch blocks the reducer`() = runBlocking {
         val action = Random.nextInt()
-        val testFlowObserver = middleware.container.stateFlow.test()
+        val testFlowObserver = middleware.container.stateFlow.testFlowObserver()
 
         middleware.blockingIntent()
 
@@ -110,7 +110,7 @@ internal class SimpleDslThreadingTest {
 
     @Test
     fun `blocking reducer blocks an intent`(): Unit = runBlocking {
-        middleware.container.stateFlow.test()
+        middleware.container.stateFlow.testFlowObserver()
 
         middleware.blockingReducer()
         withTimeout(TIMEOUT) {

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/SettingsBuilder.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/SettingsBuilder.kt
@@ -59,13 +59,3 @@ public class LiveTestSettingsBuilder internal constructor(
 
     public fun build(): RealSettings = settings
 }
-
-@Suppress("DEPRECATION")
-internal fun Container.Settings.toRealSettings() = RealSettings(
-    sideEffectBufferSize = sideEffectBufferSize,
-    idlingRegistry = idlingRegistry,
-    eventLoopDispatcher = intentDispatcher,
-    intentLaunchingDispatcher = intentDispatcher,
-    exceptionHandler = exceptionHandler,
-    repeatOnSubscribedStopTimeout = repeatOnSubscribedStopTimeout
-)

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
@@ -40,7 +40,7 @@ import org.orbitmvi.orbit.test.findTestContainer
  * @param settings Replaces the [Container.Settings] for this test
  * @return A suspending test wrapper around [ContainerHost].
  */
-@Deprecated(message = "Use overload with settings builder instead. This will be removed in the future.")
+@Deprecated(message = "Use org.orbitmvi.orbit.test.test instead. This will be removed in the future.")
 public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.test(
     initialState: STATE? = null,
     isolateFlow: Boolean = true,
@@ -69,7 +69,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE
  * @param buildSettings Builds the [RealSettings] for this test
  * @return A suspending test wrapper around [ContainerHost].
  */
-@Deprecated(message = "Use overload with settings builder instead. This will be removed in the future.")
+@Deprecated(message = "Use org.orbitmvi.orbit.test.test instead. This will be removed in the future.")
 public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.test(
     initialState: STATE? = null,
     isolateFlow: Boolean = true,
@@ -98,6 +98,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE
  * @param buildSettings Builds the [RealSettings] for this test
  * @return A suspending test wrapper around [ContainerHost].
  */
+@Deprecated(message = "Use org.orbitmvi.orbit.test.test instead. This will be removed in the future.")
 public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.test(
     initialState: STATE? = null,
     buildSettings: TestSettingsBuilder.() -> Unit = {},
@@ -120,6 +121,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE
  * @param buildSettings Builds the [RealSettings] for this test
  * @return A live test wrapper around [ContainerHost].
  */
+@Deprecated(message = "Use org.orbitmvi.orbit.test.test instead. This will be removed in the future.")
 public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.liveTest(
     initialState: STATE? = null,
     buildSettings: LiveTestSettingsBuilder.() -> Unit = {},
@@ -141,7 +143,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE
  * @param settings Replaces the [Container.Settings] for this test
  * @return A live test wrapper around [ContainerHost].
  */
-@Deprecated(message = "Use overload with settings builder instead. This will be removed in the future.")
+@Deprecated(message = "Use org.orbitmvi.orbit.test.test instead. This will be removed in the future.")
 public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.liveTest(
     initialState: STATE? = null,
     settings: Container.Settings

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/Test.kt
@@ -37,35 +37,6 @@ import org.orbitmvi.orbit.test.findTestContainer
  *
  * @param initialState The state to initialize the test container with. Omit this parameter to use the real initial state of the container.
  * @param isolateFlow Whether the intent should be isolated
- * @param settings Replaces the [Container.Settings] for this test
- * @return A suspending test wrapper around [ContainerHost].
- */
-@Deprecated(message = "Use org.orbitmvi.orbit.test.test instead. This will be removed in the future.")
-public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.test(
-    initialState: STATE? = null,
-    isolateFlow: Boolean = true,
-    settings: Container.Settings
-): SuspendingTestContainerHost<STATE, SIDE_EFFECT, CONTAINER_HOST> {
-    return container.findTestContainer().test(
-        initialState = initialState,
-        strategy = TestingStrategy.Suspending(settings.toRealSettings()),
-        testScope = null
-    ).let {
-        SuspendingTestContainerHost(this, initialState, isolateFlow)
-    }
-}
-
-/**
- *  Puts your [ContainerHost] into suspending test mode. Intents are intercepted and executed as
- *  suspending functions.
- *
- *  Allows you to test your intents in isolation. Only the intent called will actually run.
- *  Method calls on the [ContainerHost] beyond the first will be registered but not
- *  actually execute. This allows you to test your intents in isolation, disabling loopbacks
- *  that might make your tests too complex.
- *
- * @param initialState The state to initialize the test container with. Omit this parameter to use the real initial state of the container.
- * @param isolateFlow Whether the intent should be isolated
  * @param buildSettings Builds the [RealSettings] for this test
  * @return A suspending test wrapper around [ContainerHost].
  */
@@ -129,28 +100,6 @@ public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE
     return container.findTestContainer().test(
         initialState = initialState,
         strategy = TestingStrategy.Live(LiveTestSettingsBuilder(container.settings).apply(buildSettings).build()),
-        testScope = null
-    )
-        .let {
-            RegularTestContainerHost(this, initialState)
-        }
-}
-
-/**
- *  Puts your [ContainerHost] into live test mode. This mode uses a real Orbit container.
- *
- * @param initialState The state to initialize the test container with. Omit this parameter to use the real initial state of the container.
- * @param settings Replaces the [Container.Settings] for this test
- * @return A live test wrapper around [ContainerHost].
- */
-@Deprecated(message = "Use org.orbitmvi.orbit.test.test instead. This will be removed in the future.")
-public fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.liveTest(
-    initialState: STATE? = null,
-    settings: Container.Settings
-): RegularTestContainerHost<STATE, SIDE_EFFECT, CONTAINER_HOST> {
-    return container.findTestContainer().test(
-        initialState = initialState,
-        strategy = TestingStrategy.Live(settings.toRealSettings()),
         testScope = null
     )
         .let {

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestContainerHost.kt
@@ -32,8 +32,11 @@ import kotlin.test.assertEquals
 public sealed class TestContainerHost<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>>(
     actual: CONTAINER_HOST
 ) {
-    public val stateObserver: TestFlowObserver<STATE> = actual.container.stateFlow.test()
-    public val sideEffectObserver: TestFlowObserver<SIDE_EFFECT> = actual.container.sideEffectFlow.test()
+    @OptIn(OrbitInternal::class)
+    public val stateObserver: TestFlowObserver<STATE> = actual.container.stateFlow.testFlowObserver()
+
+    @OptIn(OrbitInternal::class)
+    public val sideEffectObserver: TestFlowObserver<SIDE_EFFECT> = actual.container.sideEffectFlow.testFlowObserver()
 
     protected abstract fun awaitForEmissions(verification: OrbitVerification<STATE, SIDE_EFFECT>, timeoutMillis: Long)
 

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestFlowObserver.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/TestFlowObserver.kt
@@ -27,8 +27,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.annotation.OrbitInternal
 
 /**
  * Allows you to record all observed values of a flow for easy testing.
@@ -99,4 +99,5 @@ public class TestFlowObserver<T>(flow: Flow<T>) {
 /**
  * Allows you to put a [Flow] into test mode.
  */
-public fun <T> Flow<T>.test(): TestFlowObserver<T> = TestFlowObserver(this)
+@OrbitInternal
+public fun <T> Flow<T>.testFlowObserver(): TestFlowObserver<T> = TestFlowObserver(this)

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/ContainerExt.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/ContainerExt.kt
@@ -18,10 +18,14 @@ package org.orbitmvi.orbit.test
 
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerDecorator
+import org.orbitmvi.orbit.annotation.OrbitInternal
 import org.orbitmvi.orbit.internal.LazyCreateContainerDecorator
 import org.orbitmvi.orbit.internal.TestContainerDecorator
+import org.orbitmvi.orbit.syntax.ContainerContext
 
-internal fun <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.findOnCreate(): (STATE) -> Unit {
+@OptIn(OrbitInternal::class)
+internal fun <STATE : Any, SIDE_EFFECT : Any> Container<STATE, SIDE_EFFECT>.findOnCreate():
+    suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit {
     return (this as? LazyCreateContainerDecorator<STATE, SIDE_EFFECT>)?.onCreate
         ?: (this as? ContainerDecorator<STATE, SIDE_EFFECT>)?.actual?.findOnCreate()
         ?: {}

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
@@ -98,6 +98,7 @@ public interface OrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST
 
     /**
      * Finish this test and ignore any events which have already been received.
+     * This also cancels any in-progress intents.
      */
     public suspend fun cancelAndIgnoreRemainingItems()
 }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
@@ -24,7 +24,7 @@ public interface OrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST
     /**
      * Invoke `onCreate` lambda for the [ContainerHost].
      */
-    public fun runOnCreate()
+    public fun runOnCreate(): Job
 
     /**
      * Invoke an intent on the [ContainerHost] under test.

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
@@ -16,6 +16,7 @@
 
 package org.orbitmvi.orbit.test
 
+import kotlinx.coroutines.Job
 import org.orbitmvi.orbit.ContainerHost
 
 public interface OrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> {
@@ -28,7 +29,7 @@ public interface OrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST
     /**
      * Invoke an intent on the [ContainerHost] under test.
      */
-    public fun invokeIntent(action: CONTAINER_HOST.() -> Unit)
+    public fun invokeIntent(action: CONTAINER_HOST.() -> Job): Job
 
     /**
      * Sanity check assertion. Checks if the initial state is emitted and matches

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/RealOrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/RealOrbitTestContext.kt
@@ -18,11 +18,11 @@ package org.orbitmvi.orbit.test
 
 import app.cash.turbine.ReceiveTurbine
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.Job
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import kotlin.test.assertEquals
 import kotlin.test.fail
-import kotlinx.coroutines.Job
-import org.orbitmvi.orbit.annotation.OrbitExperimental
 
 public class RealOrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>>(
     private val actual: CONTAINER_HOST,

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Test.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Test.kt
@@ -17,9 +17,6 @@
 package org.orbitmvi.orbit.test
 
 import app.cash.turbine.test
-import app.cash.turbine.withTurbineTimeout
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.map
@@ -30,8 +27,9 @@ import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.RealSettings
-import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.internal.TestingStrategy
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  *  Run tests on your [ContainerHost]. This mode uses a real Orbit container, but the container's [CoroutineDispatcher] is set to the
@@ -48,7 +46,6 @@ import org.orbitmvi.orbit.internal.TestingStrategy
  * @param validate Perform your test within this block. See [OrbitTestContext].
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalStdlibApi::class)
-@OrbitExperimental
 public suspend fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> CONTAINER_HOST.test(
     testScope: TestScope,
     initialState: STATE? = null,
@@ -71,9 +68,9 @@ public suspend fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHo
             this
         ).apply {
             validate(this)
-//            withAppropriateTimeout(timeout ?: 1.seconds) {
-//                container.findTestContainer().joinIntents()
-//            }
+            withAppropriateTimeout(timeout ?: 1.seconds) {
+                container.findTestContainer().joinIntents()
+            }
         }
     }
 }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Test.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Test.kt
@@ -17,7 +17,9 @@
 package org.orbitmvi.orbit.test
 
 import app.cash.turbine.test
+import app.cash.turbine.withTurbineTimeout
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.map
@@ -69,6 +71,9 @@ public suspend fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHo
             this
         ).apply {
             validate(this)
+//            withAppropriateTimeout(timeout ?: 1.seconds) {
+//                container.findTestContainer().joinIntents()
+//            }
         }
     }
 }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Timeout.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Timeout.kt
@@ -1,7 +1,5 @@
 package org.orbitmvi.orbit.test
 
-import kotlin.coroutines.coroutineContext
-import kotlin.time.Duration
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -16,6 +14,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.withTimeout
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal suspend fun <T> withAppropriateTimeout(

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Timeout.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Timeout.kt
@@ -1,0 +1,58 @@
+package org.orbitmvi.orbit.test
+
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.withTimeout
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal suspend fun <T> withAppropriateTimeout(
+    timeout: Duration,
+    block: suspend CoroutineScope.() -> T,
+): T {
+    return if (coroutineContext[TestCoroutineScheduler] != null) {
+        // withTimeout uses virtual time, which will hang.
+        withWallClockTimeout(timeout, block)
+    } else {
+        withTimeout(timeout, block)
+    }
+}
+
+private suspend fun <T> withWallClockTimeout(
+    timeout: Duration,
+    block: suspend CoroutineScope.() -> T,
+): T = coroutineScope {
+    val blockDeferred = async(start = CoroutineStart.UNDISPATCHED, block = block)
+
+    // Run the timeout on a scope separate from the caller. This ensures that the use of the
+    // Default dispatcher does not affect the use of a TestScheduler and its fake time.
+    @OptIn(DelicateCoroutinesApi::class)
+    val timeoutJob = GlobalScope.launch(Dispatchers.Default) { delay(timeout) }
+
+    select {
+        blockDeferred.onAwait { result ->
+            timeoutJob.cancel()
+            result
+        }
+        timeoutJob.onJoin {
+            blockDeferred.cancel()
+            throw OrbitTimeoutCancellationException("Timed out waiting for remaining intents to complete for $timeout")
+        }
+    }
+}
+
+internal class OrbitTimeoutCancellationException internal constructor(
+    message: String,
+) : CancellationException(message)

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/GeneralTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/GeneralTest.kt
@@ -20,16 +20,17 @@
 
 package org.orbitmvi.orbit
 
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.syntax.simple.intent
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 
+@Suppress("DEPRECATION")
 @ExperimentalCoroutinesApi
 internal class GeneralTest {
     private val initialState = State(Random.nextInt())

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/GeneralTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/GeneralTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.test.assertEventually
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -72,7 +73,9 @@ internal class GeneralTest {
 
         testSubject.liveTest(initialState = initialState).runOnCreate()
 
-        assertEquals(true, mockDependency.createCalled.value)
+        assertEventually {
+            assertEquals(true, mockDependency.createCalled.value)
+        }
     }
 
     @Test

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/InfiniteFlowTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/InfiniteFlowTest.kt
@@ -1,7 +1,5 @@
 package org.orbitmvi.orbit
 
-import kotlin.test.AfterTest
-import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -10,7 +8,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
+import kotlin.test.AfterTest
+import kotlin.test.Test
 
+@Suppress("DEPRECATION")
 @ExperimentalCoroutinesApi
 internal class InfiniteFlowTest {
 
@@ -43,7 +44,7 @@ internal class InfiniteFlowTest {
         }
     }
 
-    private inner class InfiniteFlowMiddleware() : ContainerHost<List<Int>, Nothing> {
+    private inner class InfiniteFlowMiddleware : ContainerHost<List<Int>, Nothing> {
         override val container: Container<List<Int>, Nothing> = scope.container(listOf(42))
 
         fun incrementForever() = intent {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/InfiniteFlowTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/InfiniteFlowTest.kt
@@ -1,16 +1,15 @@
 package org.orbitmvi.orbit
 
+import kotlin.test.AfterTest
+import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
-import kotlin.test.AfterTest
-import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
 internal class InfiniteFlowTest {
@@ -23,7 +22,7 @@ internal class InfiniteFlowTest {
     }
 
     @Test
-    fun `infinite flow can be tested`() = runTest {
+    fun `infinite flow can be tested`() {
         val dispatcher = UnconfinedTestDispatcher()
         val middleware = InfiniteFlowMiddleware().liveTest {
             this.dispatcher = dispatcher
@@ -44,7 +43,7 @@ internal class InfiniteFlowTest {
         }
     }
 
-    private inner class InfiniteFlowMiddleware : ContainerHost<List<Int>, Nothing> {
+    private inner class InfiniteFlowMiddleware() : ContainerHost<List<Int>, Nothing> {
         override val container: Container<List<Int>, Nothing> = scope.container(listOf(42))
 
         fun incrementForever() = intent {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedSideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedSideEffectTest.kt
@@ -81,7 +81,7 @@ internal class ParameterisedSideEffectTest(blocking: Boolean) {
         ContainerHost<State, Int> {
         override val container = scope.container<State, Int>(initialState)
 
-        fun something(action: Int): Unit = intent {
+        fun something(action: Int) = intent {
             postSideEffect(action)
             somethingElse(action.toString())
         }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedSideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedSideEffectTest.kt
@@ -20,19 +20,20 @@
 
 package org.orbitmvi.orbit
 
-import kotlin.random.Random
-import kotlin.test.assertContains
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import kotlin.random.Random
+import kotlin.test.assertContains
+import kotlin.test.assertFailsWith
 
+@Suppress("DEPRECATION")
 @ExperimentalCoroutinesApi
 internal class ParameterisedSideEffectTest(private val blocking: Boolean) {
     companion object {
-        const val TIMEOUT = 1000L
+        const val TIMEOUT = 2000L
     }
 
     private val initialState = State()

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedSideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedSideEffectTest.kt
@@ -20,38 +20,25 @@
 
 package org.orbitmvi.orbit
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
-import org.orbitmvi.orbit.syntax.simple.intent
-import org.orbitmvi.orbit.syntax.simple.postSideEffect
-import org.orbitmvi.orbit.test.assertContains
 import kotlin.random.Random
 import kotlin.test.assertContains
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
 
 @ExperimentalCoroutinesApi
-internal class ParameterisedSideEffectTest(blocking: Boolean) {
+internal class ParameterisedSideEffectTest(private val blocking: Boolean) {
     companion object {
         const val TIMEOUT = 1000L
     }
 
     private val initialState = State()
-    private val scope = CoroutineScope(Job())
-    private val testSubject = if (blocking) {
-        SideEffectTestMiddleware().test(
-            initialState = initialState
-        )
-    } else {
-        SideEffectTestMiddleware().liveTest(initialState)
-    }
 
-    fun cancel() {
-        scope.cancel()
-    }
-
-    fun `succeeds if posted side effects match expected side effects`() {
+    fun `succeeds if posted side effects match expected side effects`() = runTest {
+        val testSubject = testSubject(this)
         val sideEffects = List(Random.nextInt(1, 5)) { Random.nextInt() }
 
         sideEffects.forEach { testSubject.call { something(it) } }
@@ -61,7 +48,8 @@ internal class ParameterisedSideEffectTest(blocking: Boolean) {
         }
     }
 
-    fun `fails if posted side effects do not match expected side effects`() {
+    fun `fails if posted side effects do not match expected side effects`() = runTest {
+        val testSubject = testSubject(this)
         val sideEffects = List(Random.nextInt(1, 5)) { Random.nextInt() }
         val sideEffects2 = List(Random.nextInt(1, 5)) { Random.nextInt() }
 
@@ -77,9 +65,17 @@ internal class ParameterisedSideEffectTest(blocking: Boolean) {
         assertContains(throwable.message.orEmpty(), sideEffects.toString())
     }
 
-    private inner class SideEffectTestMiddleware :
+    private fun testSubject(scope: TestScope) = if (blocking) {
+        SideEffectTestMiddleware(scope).test(
+            initialState = initialState
+        )
+    } else {
+        SideEffectTestMiddleware(scope).liveTest(initialState)
+    }
+
+    private inner class SideEffectTestMiddleware(scope: TestScope) :
         ContainerHost<State, Int> {
-        override val container = scope.container<State, Int>(initialState)
+        override val container = scope.backgroundScope.container<State, Int>(initialState)
 
         fun something(action: Int) = intent {
             postSideEffect(action)
@@ -93,11 +89,11 @@ internal class ParameterisedSideEffectTest(blocking: Boolean) {
 
     private data class State(val count: Int = Random.nextInt())
 
-    private fun <STATE : Any, SIDE_EFFECT : Any, T : ContainerHost<STATE, SIDE_EFFECT>> TestContainerHost<STATE, SIDE_EFFECT, T>.call(
+    private suspend fun <STATE : Any, SIDE_EFFECT : Any, T : ContainerHost<STATE, SIDE_EFFECT>> TestContainerHost<STATE, SIDE_EFFECT, T>.call(
         block: T.() -> Unit
     ) {
         when (this) {
-            is SuspendingTestContainerHost -> runBlocking { testIntent { block() } }
+            is SuspendingTestContainerHost -> testIntent { block() }
             is RegularTestContainerHost -> testIntent { block() }
         }
     }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedStateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedStateTest.kt
@@ -288,7 +288,7 @@ internal class ParameterisedStateTest(blocking: Boolean) {
         ContainerHost<State, Nothing> {
         override val container = scope.container<State, Nothing>(initialState)
 
-        fun something(action: Int): Unit = intent {
+        fun something(action: Int) = intent {
             reduce {
                 State(count = action)
             }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedStateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/ParameterisedStateTest.kt
@@ -20,15 +20,16 @@
 
 package org.orbitmvi.orbit
 
-import kotlin.random.Random
-import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.test.assertContains
+import kotlin.random.Random
+import kotlin.test.assertFailsWith
 
+@Suppress("DEPRECATION")
 @ExperimentalCoroutinesApi
 internal class ParameterisedStateTest(private val blocking: Boolean) {
     companion object {
@@ -105,7 +106,7 @@ internal class ParameterisedStateTest(private val blocking: Boolean) {
 
         throwable.message.assertContains(
             "Expected 1 states but more were emitted:\n" +
-                    "[State(count=$action2)]"
+                "[State(count=$action2)]"
         )
     }
 
@@ -132,7 +133,7 @@ internal class ParameterisedStateTest(private val blocking: Boolean) {
 
         throwable.message.assertContains(
             "Failed assertions at indices 2..2, expected states but never received:\n" +
-                    "[State(count=$action3)]"
+                "[State(count=$action3)]"
         )
     }
 
@@ -161,7 +162,7 @@ internal class ParameterisedStateTest(private val blocking: Boolean) {
 
         throwable.message.assertContains(
             "Failed assertions at indices 2..3, expected states but never received:\n" +
-                    "[State(count=$action3), State(count=$action4)]"
+                "[State(count=$action3), State(count=$action4)]"
         )
     }
 
@@ -283,9 +284,9 @@ internal class ParameterisedStateTest(private val blocking: Boolean) {
 
         throwable.message.assertContains(
             "Expected 2 states but more were emitted:\n" +
-                    "[State(count=$action2)]\n\n" +
-                    "Caution: 1 assertions were dropped as they encountered a current state " +
-                    "which already satisfied them."
+                "[State(count=$action2)]\n\n" +
+                "Caution: 1 assertions were dropped as they encountered a current state " +
+                "which already satisfied them."
         )
     }
 

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/RepeatOnSubscriptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/RepeatOnSubscriptionTest.kt
@@ -16,8 +16,6 @@
 
 package org.orbitmvi.orbit
 
-import kotlin.random.Random
-import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -25,7 +23,10 @@ import kotlinx.coroutines.withTimeout
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.syntax.simple.repeatOnSubscription
+import kotlin.random.Random
+import kotlin.test.Test
 
+@Suppress("DEPRECATION")
 @ExperimentalCoroutinesApi
 internal class RepeatOnSubscriptionTest {
     private val initialState = State()

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/SideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/SideEffectTest.kt
@@ -26,12 +26,7 @@ import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
 internal class SideEffectTest {
-    lateinit var testCase: ParameterisedSideEffectTest
-
-    @AfterTest
-    fun afterTest() {
-        testCase.cancel()
-    }
+    private lateinit var testCase: ParameterisedSideEffectTest
 
     @Test
     fun `BLOCKING - succeeds if posted side effects match expected side effects`() {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/SideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/SideEffectTest.kt
@@ -21,7 +21,6 @@
 package org.orbitmvi.orbit
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlin.test.AfterTest
 import kotlin.test.Test
 
 @ExperimentalCoroutinesApi

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/StateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/StateTest.kt
@@ -21,7 +21,6 @@
 package org.orbitmvi.orbit
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlin.test.AfterTest
 import kotlin.test.Test
 
 @ExperimentalCoroutinesApi

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/StateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/StateTest.kt
@@ -26,12 +26,7 @@ import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
 internal class StateTest {
-    lateinit var testCase: ParameterisedStateTest
-
-    @AfterTest
-    fun afterTest() {
-        testCase.cancel()
-    }
+    private lateinit var testCase: ParameterisedStateTest
 
     @Test
     fun `BLOCKING - succeeds if initial state matches expected state`() {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit.test
+
+//import kotlinx.coroutines.CoroutineScope
+import kotlin.random.Random
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+//import org.orbitmvi.orbit.ContainerHost
+//import org.orbitmvi.orbit.annotation.OrbitExperimental
+//import org.orbitmvi.orbit.container
+//import org.orbitmvi.orbit.syntax.simple.intent
+//import org.orbitmvi.orbit.syntax.simple.postSideEffect
+//import org.orbitmvi.orbit.syntax.simple.reduce
+//import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertFails
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
+import org.orbitmvi.orbit.container
+import org.orbitmvi.orbit.syntax.simple.intent
+
+//import kotlin.test.assertEquals
+//import kotlin.test.assertFailsWith
+//import kotlin.test.assertTrue
+//import kotlinx.coroutines.CoroutineExceptionHandler
+//import kotlinx.coroutines.delay
+//
+//@OptIn(OrbitExperimental::class)
+@ExperimentalCoroutinesApi
+class ExceptionTest {
+
+    private val initialState = State()
+
+    @OptIn(OrbitExperimental::class)
+    @Test
+    fun `succeeds if initial state matches expected state`() = runTest {
+
+//        assertFails {
+            ExceptionTestMiddleware(this).test(this) {
+                expectInitialState()
+
+                val job = invokeIntent { boom() }
+
+                job.join()
+            }
+//        }
+
+//
+//        ExceptionTestMiddleware(this).boom()
+    }
+
+    private inner class ExceptionTestMiddleware(scope: CoroutineScope) : ContainerHost<State, Int> {
+        override val container = scope.container<State, Int>(initialState)
+
+        fun boom() = intent {
+            throw IllegalStateException("Boom!")
+        }
+    }
+
+    private data class State(
+        val count: Int = Random.nextInt(),
+        val list: List<Int> = emptyList()
+    )
+}

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
@@ -17,9 +17,6 @@
 package org.orbitmvi.orbit.test
 
 //import kotlinx.coroutines.CoroutineScope
-import kotlin.random.Random
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runTest
 //import org.orbitmvi.orbit.ContainerHost
 //import org.orbitmvi.orbit.annotation.OrbitExperimental
 //import org.orbitmvi.orbit.container
@@ -27,10 +24,12 @@ import kotlinx.coroutines.test.runTest
 //import org.orbitmvi.orbit.syntax.simple.postSideEffect
 //import org.orbitmvi.orbit.syntax.simple.reduce
 //import kotlin.random.Random
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertFails
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.container
@@ -50,20 +49,18 @@ class ExceptionTest {
 
     @OptIn(OrbitExperimental::class)
     @Test
-    fun `succeeds if initial state matches expected state`() = runTest {
+    fun `exceptions thrown during test can be asserted on`() {
+        assertFails {
+            runTest {
+                ExceptionTestMiddleware(this).test(this) {
+                    expectInitialState()
 
-//        assertFails {
-            ExceptionTestMiddleware(this).test(this) {
-                expectInitialState()
+                    val job = invokeIntent { boom() }
 
-                val job = invokeIntent { boom() }
-
-                job.join()
+                    job.join()
+                }
             }
-//        }
-
-//
-//        ExceptionTestMiddleware(this).boom()
+        }
     }
 
     private inner class ExceptionTestMiddleware(scope: CoroutineScope) : ContainerHost<State, Int> {
@@ -79,3 +76,4 @@ class ExceptionTest {
         val list: List<Int> = emptyList()
     )
 }
+

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
@@ -16,32 +16,17 @@
 
 package org.orbitmvi.orbit.test
 
-//import kotlinx.coroutines.CoroutineScope
-//import org.orbitmvi.orbit.ContainerHost
-//import org.orbitmvi.orbit.annotation.OrbitExperimental
-//import org.orbitmvi.orbit.container
-//import org.orbitmvi.orbit.syntax.simple.intent
-//import org.orbitmvi.orbit.syntax.simple.postSideEffect
-//import org.orbitmvi.orbit.syntax.simple.reduce
-//import kotlin.random.Random
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertFails
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertFails
 
-//import kotlin.test.assertEquals
-//import kotlin.test.assertFailsWith
-//import kotlin.test.assertTrue
-//import kotlinx.coroutines.CoroutineExceptionHandler
-//import kotlinx.coroutines.delay
-//
-//@OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi
 class ExceptionTest {
 
@@ -63,8 +48,8 @@ class ExceptionTest {
         }
     }
 
-    private inner class ExceptionTestMiddleware(scope: CoroutineScope) : ContainerHost<State, Int> {
-        override val container = scope.container<State, Int>(initialState)
+    private inner class ExceptionTestMiddleware(scope: TestScope) : ContainerHost<State, Int> {
+        override val container = scope.backgroundScope.container<State, Int>(initialState)
 
         fun boom() = intent {
             throw IllegalStateException("Boom!")
@@ -76,4 +61,3 @@ class ExceptionTest {
         val list: List<Int> = emptyList()
     )
 }
-

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InfiniteFlowTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InfiniteFlowTest.kt
@@ -39,7 +39,7 @@ internal class InfiniteFlowTest {
 
     @Test
     fun `infinite flow can be tested with delay skipping`() = runTest {
-        InfiniteFlowMiddleware().test(this) {
+        InfiniteFlowMiddleware(this).test(this) {
             expectInitialState()
 
             invokeIntent { incrementForever() }
@@ -57,7 +57,7 @@ internal class InfiniteFlowTest {
     fun `infinite flow can be tested without delay skipping`() = runTest {
         val scope = TestScope()
 
-        InfiniteFlowMiddleware().test(scope) {
+        InfiniteFlowMiddleware(this).test(scope) {
             expectInitialState()
 
             val job = invokeIntent { incrementForever() }
@@ -74,8 +74,8 @@ internal class InfiniteFlowTest {
         }
     }
 
-    private inner class InfiniteFlowMiddleware : ContainerHost<List<Int>, Nothing> {
-        override val container: Container<List<Int>, Nothing> = MainScope().container(listOf(42))
+    private inner class InfiniteFlowMiddleware(testScope: TestScope) : ContainerHost<List<Int>, Nothing> {
+        override val container: Container<List<Int>, Nothing> = testScope.backgroundScope.container(listOf(42))
 
         fun incrementForever() = intent {
             while (coroutineContext.isActive) {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InfiniteFlowTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InfiniteFlowTest.kt
@@ -16,11 +16,7 @@
 
 package org.orbitmvi.orbit.test
 
-import kotlin.coroutines.coroutineContext
-import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.TestScope
@@ -32,6 +28,9 @@ import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
+import kotlin.coroutines.coroutineContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @ExperimentalCoroutinesApi
 @OptIn(OrbitExperimental::class)
@@ -71,8 +70,11 @@ internal class InfiniteFlowTest {
             assertEquals(listOf(42, 43, 44, 45), awaitState())
 
             job.cancel()
+            scope.advanceTimeBy(1)
         }
     }
+
+//    org.orbitmvi.orbit.SuspendingStrategyDispatchTest[jvm] > suspending test maintains test dispatcher through runTest[jvm] PASSED
 
     private inner class InfiniteFlowMiddleware(testScope: TestScope) : ContainerHost<List<Int>, Nothing> {
         override val container: Container<List<Int>, Nothing> = testScope.backgroundScope.container(listOf(42))

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InitTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InitTest.kt
@@ -62,7 +62,7 @@ internal class InitTest {
     }
 
     private fun TestScope.createMiddleware(dependency: BogusDependency = FakeDependency()): GeneralTestMiddleware {
-        return GeneralTestMiddleware(this, dependency)
+        return GeneralTestMiddleware(this.backgroundScope, dependency)
     }
 
     private inner class GeneralTestMiddleware(coroutineScope: CoroutineScope, val dependency: BogusDependency) :

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/IntentJobsTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/IntentJobsTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit.test
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
+import org.orbitmvi.orbit.container
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import kotlin.coroutines.coroutineContext
+import kotlin.test.Test
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+
+@OptIn(OrbitExperimental::class)
+@ExperimentalCoroutinesApi
+class IntentJobsTest {
+
+    private val initialState = 0
+
+    @Test
+    fun `unfinished intents at the end of the test cause the test to fail`() {
+        assertFails {
+            runTest {
+                IntentJobsMiddleware(this).test(this) {
+                    expectInitialState()
+
+                    invokeIntent { infiniteIntent() }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `unfinished intents at the end of the test may be ignored`() = runTest {
+        IntentJobsMiddleware(this).test(this) {
+            expectInitialState()
+
+            invokeIntent { infiniteIntent() }
+            cancelAndIgnoreRemainingItems()
+        }
+    }
+
+    @Test
+    fun `intents may be cancelled`() = runTest {
+        IntentJobsMiddleware(this).test(this) {
+            expectInitialState()
+
+            val job = invokeIntent { infiniteIntent() }
+
+            job.cancel()
+        }
+    }
+
+    @Test
+    fun `intents may be joined`() = runTest {
+        val scope = TestScope()
+        IntentJobsMiddleware(this).test(scope) {
+            expectInitialState()
+
+            val job = invokeIntent { longIntent() }
+
+            scope.testScheduler.advanceTimeBy(300)
+
+            launch {
+                job.join()
+            }
+            assertTrue { job.isActive }
+            scope.testScheduler.advanceTimeBy(1)
+            assertTrue { job.isCompleted }
+            expectState { this + 2 }
+        }
+    }
+
+    private inner class IntentJobsMiddleware(scope: TestScope) : ContainerHost<Int, Int> {
+        override val container = scope.backgroundScope.container<Int, Int>(initialState)
+
+        fun infiniteIntent() = intent {
+            while (coroutineContext.isActive) {
+                delay(3000)
+                reduce { state + 1 }
+            }
+        }
+
+        fun longIntent() = intent {
+            delay(300)
+            reduce { state + 2 }
+        }
+    }
+}

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
@@ -16,10 +16,6 @@
 
 package org.orbitmvi.orbit.test
 
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -29,6 +25,9 @@ import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
@@ -16,6 +16,9 @@
 
 package org.orbitmvi.orbit.test
 
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -25,9 +28,6 @@ import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi
@@ -79,13 +79,13 @@ class ItemsTest {
         ContainerHost<State, Int> {
         override val container = scope.container<State, Int>(initialState)
 
-        fun newState(action: Int): Unit = intent {
+        fun newState(action: Int) = intent {
             reduce {
                 State(count = action)
             }
         }
 
-        fun newSideEffect(action: Int): Unit = intent {
+        fun newSideEffect(action: Int) = intent {
             postSideEffect(action)
         }
     }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
@@ -75,9 +76,9 @@ class ItemsTest {
         }
     }
 
-    private inner class ItemTestMiddleware(scope: CoroutineScope) :
+    private inner class ItemTestMiddleware(scope: TestScope) :
         ContainerHost<State, Int> {
-        override val container = scope.container<State, Int>(initialState)
+        override val container = scope.backgroundScope.container<State, Int>(initialState)
 
         fun newState(action: Int) = intent {
             reduce {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
@@ -16,9 +16,6 @@
 
 package org.orbitmvi.orbit.test
 
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -28,6 +25,9 @@ import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.syntax.simple.repeatOnSubscription
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
@@ -28,6 +28,7 @@ import org.orbitmvi.orbit.syntax.simple.repeatOnSubscription
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.coroutines.test.TestScope
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
@@ -16,8 +16,11 @@
 
 package org.orbitmvi.orbit.test
 
-import kotlinx.coroutines.CoroutineScope
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
@@ -25,10 +28,6 @@ import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.syntax.simple.repeatOnSubscription
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlinx.coroutines.test.TestScope
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi
@@ -46,8 +45,8 @@ class RepeatOnSubscriptionTest {
         }
     }
 
-    private inner class TestMiddleware(scope: CoroutineScope) : ContainerHost<State, Nothing> {
-        override val container = scope.container<State, Nothing>(initialState)
+    private inner class TestMiddleware(scope: TestScope) : ContainerHost<State, Nothing> {
+        override val container = scope.backgroundScope.container<State, Nothing>(initialState)
 
         fun callOnSubscription(externalCall: suspend () -> Int) = intent {
             repeatOnSubscription {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.TestScope
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi
@@ -117,11 +118,11 @@ class SideEffectTest {
     private inner class SideEffectTestMiddleware(scope: CoroutineScope) : ContainerHost<State, Int> {
         override val container = scope.container<State, Int>(initialState)
 
-        fun newState(count: Int): Unit = intent {
+        fun newState(count: Int) = intent {
             reduce { state.copy(count = count) }
         }
 
-        fun something(action: Int): Unit = intent {
+        fun something(action: Int) = intent {
             postSideEffect(action)
             somethingElse(action.toString())
         }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
@@ -16,11 +16,6 @@
 
 package org.orbitmvi.orbit.test
 
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -30,6 +25,11 @@ import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
@@ -16,8 +16,13 @@
 
 package org.orbitmvi.orbit.test
 
-import kotlinx.coroutines.CoroutineScope
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
@@ -25,12 +30,6 @@ import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
-import kotlinx.coroutines.test.TestScope
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi
@@ -115,8 +114,8 @@ class SideEffectTest {
         }
     }
 
-    private inner class SideEffectTestMiddleware(scope: CoroutineScope) : ContainerHost<State, Int> {
-        override val container = scope.container<State, Int>(initialState)
+    private inner class SideEffectTestMiddleware(scope: TestScope) : ContainerHost<State, Int> {
+        override val container = scope.backgroundScope.container<State, Int>(initialState)
 
         fun newState(count: Int) = intent {
             reduce { state.copy(count = count) }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
@@ -16,8 +16,13 @@
 
 package org.orbitmvi.orbit.test
 
-import kotlinx.coroutines.CoroutineScope
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
@@ -25,12 +30,6 @@ import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
-import kotlinx.coroutines.test.TestScope
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi
@@ -261,9 +260,9 @@ class StateTest {
         }
     }
 
-    private inner class StateTestMiddleware(scope: CoroutineScope) :
+    private inner class StateTestMiddleware(scope: TestScope) :
         ContainerHost<State, Int> {
-        override val container = scope.container<State, Int>(initialState)
+        override val container = scope.backgroundScope.container<State, Int>(initialState)
 
         fun newCount(action: Int) = intent {
             reduce {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.TestScope
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi
@@ -107,7 +108,7 @@ class StateTest {
                 assertEquals(State(count = action3), awaitState())
             }
         }.also {
-            assertEquals("No value produced in 1s", it.message)
+            assertEquals("No value produced in 3s", it.message)
         }
     }
 
@@ -264,19 +265,19 @@ class StateTest {
         ContainerHost<State, Int> {
         override val container = scope.container<State, Int>(initialState)
 
-        fun newCount(action: Int): Unit = intent {
+        fun newCount(action: Int) = intent {
             reduce {
                 State(count = action)
             }
         }
 
-        fun newList(action: Int): Unit = intent {
+        fun newList(action: Int) = intent {
             reduce {
                 state.copy(list = state.list + action)
             }
         }
 
-        fun newSideEffect(action: Int): Unit = intent {
+        fun newSideEffect(action: Int) = intent {
             postSideEffect(action)
         }
     }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
@@ -16,11 +16,6 @@
 
 package org.orbitmvi.orbit.test
 
-import kotlin.random.Random
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -30,6 +25,11 @@ import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 @OptIn(OrbitExperimental::class)
 @ExperimentalCoroutinesApi

--- a/orbit-test/src/jvmTest/kotlin/org/orbitmvi/orbit/SuspendingStrategyDispatchTest.kt
+++ b/orbit-test/src/jvmTest/kotlin/org/orbitmvi/orbit/SuspendingStrategyDispatchTest.kt
@@ -17,17 +17,18 @@
 
 package org.orbitmvi.orbit
 
-import kotlin.random.Random
-import kotlin.system.measureTimeMillis
-import kotlin.test.Test
-import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
+import kotlin.random.Random
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
+@Suppress("DEPRECATION")
 @ExperimentalCoroutinesApi
 internal class SuspendingStrategyDispatchTest {
     private val initialState = State()

--- a/orbit-test/src/jvmTest/kotlin/org/orbitmvi/orbit/SuspendingStrategyDispatchTest.kt
+++ b/orbit-test/src/jvmTest/kotlin/org/orbitmvi/orbit/SuspendingStrategyDispatchTest.kt
@@ -74,7 +74,7 @@ internal class SuspendingStrategyDispatchTest {
             }
         }
 
-        fun somethingInBackground(action: Int): Unit = intent {
+        fun somethingInBackground(action: Int) = intent {
             delay(5000)
             reduce {
                 State(count = action)

--- a/orbit-test/src/jvmTest/kotlin/org/orbitmvi/orbit/SuspendingStrategyDispatchTest.kt
+++ b/orbit-test/src/jvmTest/kotlin/org/orbitmvi/orbit/SuspendingStrategyDispatchTest.kt
@@ -17,30 +17,20 @@
 
 package org.orbitmvi.orbit
 
-import kotlinx.coroutines.CoroutineScope
+import kotlin.random.Random
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
-import kotlin.random.Random
-import kotlin.system.measureTimeMillis
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 internal class SuspendingStrategyDispatchTest {
     private val initialState = State()
-
-    private val scope = CoroutineScope(Job())
-
-    @AfterTest
-    fun afterTest() {
-        scope.cancel()
-    }
 
     @Test
     fun `suspending test maintains test dispatcher through runTest`() = runTest {
@@ -48,7 +38,7 @@ internal class SuspendingStrategyDispatchTest {
             val initAction = Random.nextInt()
             val action = Random.nextInt()
 
-            val testSubject = StateTestMiddleware(initAction).test(initialState)
+            val testSubject = StateTestMiddleware(this, initAction).test(initialState)
 
             testSubject.runOnCreate()
             testSubject.testIntent { somethingInBackground(action) }
@@ -63,9 +53,9 @@ internal class SuspendingStrategyDispatchTest {
         assertTrue { executionTime < 1000 }
     }
 
-    private inner class StateTestMiddleware(initAction: Int) :
+    private inner class StateTestMiddleware(scope: TestScope, initAction: Int) :
         ContainerHost<State, Nothing> {
-        override val container = scope.container<State, Nothing>(initialState) {
+        override val container = scope.backgroundScope.container<State, Nothing>(initialState) {
             intent {
                 delay(5000)
                 reduce {

--- a/orbit-viewmodel/orbit-viewmodel_build.gradle.kts
+++ b/orbit-viewmodel/orbit-viewmodel_build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     testImplementation(libs.kotlinCoroutinesTest)
 
     testImplementation(libs.androidxCoreTesting)
+    testImplementation(libs.turbine)
 }
 
 android {

--- a/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensions.kt
+++ b/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensions.kt
@@ -66,13 +66,13 @@ fun <STATE : Parcelable, SIDE_EFFECT : Any> ViewModel.container(
     initialState: STATE,
     savedStateHandle: SavedStateHandle,
     buildSettings: SettingsBuilder.() -> Unit = {},
-    onCreate: (suspend SimpleSyntax<STATE, SIDE_EFFECT>.(STATE) -> Unit)? = null
+    onCreate: (suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit)? = null
 ): Container<STATE, SIDE_EFFECT> {
     val savedState: STATE? = savedStateHandle[SAVED_STATE_KEY]
     val state = savedState ?: initialState
 
     val realContainer: Container<STATE, SIDE_EFFECT> =
-        viewModelScope.container(state, buildSettings) { onCreate?.let { it(state) } }
+        viewModelScope.container(state, buildSettings, onCreate)
 
     return SavedStateContainerDecorator(
         realContainer,

--- a/orbit-viewmodel/src/test/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensionsKtTest.kt
+++ b/orbit-viewmodel/src/test/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensionsKtTest.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.ViewModel
 import kotlinx.parcelize.Parcelize
 import org.junit.Test
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.test
@@ -105,9 +106,9 @@ class ViewModelExtensionsKtTest {
     private class Middleware(
         savedStateHandle: SavedStateHandle,
         initialState: TestState,
-        onCreate: ((TestState) -> Unit)? = null
+        onCreate: (suspend SimpleSyntax<TestState, Int>.(TestState) -> Unit)? = null
     ) : ContainerHost<TestState, Int>, ViewModel() {
-        override val container = container<TestState, Int>(
+        override val container = container(
             initialState = initialState,
             savedStateHandle = savedStateHandle,
             onCreate = onCreate

--- a/orbit-viewmodel/src/test/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensionsKtTest.kt
+++ b/orbit-viewmodel/src/test/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensionsKtTest.kt
@@ -23,16 +23,21 @@ package org.orbitmvi.orbit.viewmodel
 import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlinx.parcelize.Parcelize
 import org.junit.Test
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitInternal
 import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
-import org.orbitmvi.orbit.test
+import org.orbitmvi.orbit.test.test
+import org.orbitmvi.orbit.testFlowObserver
 import kotlin.random.Random
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class, OrbitInternal::class)
 class ViewModelExtensionsKtTest {
     @Test
     fun `When saved state is present it is read`() {
@@ -61,52 +66,46 @@ class ViewModelExtensionsKtTest {
         val something = Random.nextInt()
         val savedStateHandle = SavedStateHandle()
         val middleware = Middleware(savedStateHandle, initialState)
-        val testStateObserver = middleware.container.stateFlow.test()
+        val testStateObserver = middleware.container.stateFlow.testFlowObserver()
 
         middleware.something(something)
 
         testStateObserver.awaitCount(2)
 
-        assertEquals(TestState(something), savedStateHandle.get<TestState?>(SAVED_STATE_KEY))
+        assertEquals(TestState(something), savedStateHandle[SAVED_STATE_KEY])
     }
 
     @Test
-    fun `When saved state is present calls onCreate with true`() {
+    fun `When saved state is present calls onCreate with restored state`() = runTest {
         val initialState = TestState()
         val savedState = TestState()
         val savedStateHandle = SavedStateHandle(mapOf(SAVED_STATE_KEY to savedState))
-        var onCreateState: TestState? = null
 
-        val middleware = Middleware(savedStateHandle, initialState) {
-            onCreateState = it
+        Middleware(savedStateHandle, initialState) {
+            assertEquals(savedState, state)
+        }.test(this) {
+            expectInitialState()
+            runOnCreate()
         }
-
-        // Used to trigger execution of onCreate
-        middleware.container.stateFlow.test().awaitCount(1)
-
-        assertEquals(savedState, onCreateState)
     }
 
     @Test
-    fun `When saved state is not present calls onCreate with false`() {
+    fun `When saved state is not present calls onCreate with initial state`() = runTest {
         val initialState = TestState()
         val savedStateHandle = SavedStateHandle()
-        var onCreateState: TestState? = null
 
-        val middleware = Middleware(savedStateHandle, initialState) {
-            onCreateState = it
+        Middleware(savedStateHandle, initialState) {
+            assertEquals(initialState, state)
+        }.test(this) {
+            expectInitialState()
+            runOnCreate()
         }
-
-        // Used to trigger execution of onCreate
-        middleware.container.stateFlow.test().awaitCount(1)
-
-        assertEquals(initialState, onCreateState)
     }
 
     private class Middleware(
         savedStateHandle: SavedStateHandle,
         initialState: TestState,
-        onCreate: (suspend SimpleSyntax<TestState, Int>.(TestState) -> Unit)? = null
+        onCreate: (suspend SimpleSyntax<TestState, Int>.() -> Unit)? = null
     ) : ContainerHost<TestState, Int>, ViewModel() {
         override val container = container(
             initialState = initialState,

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/viewmodel/PostDetailsViewModel.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/viewmodel/PostDetailsViewModel.kt
@@ -37,7 +37,7 @@ class PostDetailsViewModel(
 ) : ViewModel(), ContainerHost<PostDetailState, Nothing> {
 
     override val container = container<PostDetailState, Nothing>(PostDetailState.NoDetailsAvailable(postOverview), savedStateHandle) {
-        if (it !is PostDetailState.Details) {
+        if (state !is PostDetailState.Details) {
             loadDetails()
         }
     }

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
@@ -46,7 +46,7 @@ class PostListViewModel(
         savedStateHandle = savedStateHandle,
         buildSettings = { this.exceptionHandler = exceptionHandler }
     ) {
-        if (it.overviews.isEmpty()) {
+        if (state.overviews.isEmpty()) {
             loadOverviews()
         }
     }

--- a/samples/orbit-posts/src/test/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/viewmodel/PostDetailsViewModelTest.kt
+++ b/samples/orbit-posts/src/test/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/viewmodel/PostDetailsViewModelTest.kt
@@ -36,6 +36,7 @@ import org.orbitmvi.orbit.sample.posts.domain.repositories.Status
 import org.orbitmvi.orbit.test
 import java.io.IOException
 
+@Suppress("DEPRECATION")
 @ExtendWith(InstantTaskExecutorExtension::class)
 class PostDetailsViewModelTest {
 

--- a/samples/orbit-posts/src/test/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModelTest.kt
+++ b/samples/orbit-posts/src/test/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModelTest.kt
@@ -32,6 +32,7 @@ import org.orbitmvi.orbit.sample.posts.domain.repositories.PostOverview
 import org.orbitmvi.orbit.sample.posts.domain.repositories.PostRepository
 import org.orbitmvi.orbit.test
 
+@Suppress("DEPRECATION")
 @ExtendWith(InstantTaskExecutorExtension::class)
 class PostListViewModelTest {
 

--- a/samples/orbit-stocklist/src/main/kotlin/org/orbitmvi/orbit/sample/stocklist/detail/business/DetailViewModel.kt
+++ b/samples/orbit-stocklist/src/main/kotlin/org/orbitmvi/orbit/sample/stocklist/detail/business/DetailViewModel.kt
@@ -38,7 +38,7 @@ class DetailViewModel(
     override val container =
         container<DetailState, Nothing>(DetailState(), savedStateHandle) { requestStock() }
 
-    private fun requestStock(): Unit = intent(registerIdling = false) {
+    private fun requestStock() = intent(registerIdling = false) {
         stockRepository.stockDetails(itemName).collect {
             reduce {
                 state.copy(stock = it)

--- a/samples/orbit-stocklist/src/main/kotlin/org/orbitmvi/orbit/sample/stocklist/list/business/ListViewModel.kt
+++ b/samples/orbit-stocklist/src/main/kotlin/org/orbitmvi/orbit/sample/stocklist/list/business/ListViewModel.kt
@@ -38,7 +38,7 @@ class ListViewModel(
 
     override val container = container<ListState, ListSideEffect>(ListState(), savedStateHandle) { requestStocks() }
 
-    private fun requestStocks(): Unit = intent(registerIdling = false) {
+    private fun requestStocks() = intent(registerIdling = false) {
         repeatOnSubscription {
             stockRepository.stockList().collect {
                 reduce {

--- a/website/docs/Core/overview.md
+++ b/website/docs/Core/overview.md
@@ -260,7 +260,7 @@ class Example : ContainerHost<ExampleState, ExampleSideEffect> {
 
 :::note
 
-`reduce` is a special operator, where state is captured when it's lambda is
+`reduce` is a special operator, where state is captured when its lambda is
 invoked. This means that within a `reduce` block, your state is guaranteed
 not to change.
 

--- a/website/docs/Test/overview.md
+++ b/website/docs/Test/overview.md
@@ -5,16 +5,20 @@ sidebar_label: 'Overview'
 
 # Unit Testing module
 
+:::caution
+
+This framework is now **deprecated**. It will be removed in Orbit version 6.0.0.
+
+Use the [new framework](new.md) instead.
+
+:::
+
 This module provides a simple unit testing framework for your Orbit
 [ContainerHosts](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/).
 
 ```kotlin
 testImplementation("org.orbit-mvi:orbit-test:<latest-version>")
 ```
-
-There is also a new [experimental version](experimental.md) available. It is 
-based in the same module with the files all located under the 
-`org.orbitmvi.orbit.test` package.
 
 ## Testing goals
 


### PR DESCRIPTION
This PR adds a number of improvements to the new testing framework:

**Breaking changes**

- onCreate lambda is now an implicit `intent`
- `intent` now returns `Job`
- Removed deprecated `container` factory functions
- Removed deprecated `test` functions

**Other changes**

- Testing framework now checks that there are no in-progress intents at the end of the test and fails if this is the case
- Intents fired during testing can now be joined or cancelled using the returned job.
- Deprecated the old testing framework
- Removed experimental annotation from new testing framework