### PR TITLE
Fix/orbit 6 issues

### DIFF
--- a/orbit-core/orbit-core_build.gradle.kts
+++ b/orbit-core/orbit-core_build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
         }
         commonMain {
             dependencies {
-                implementation(libs.kotlinCoroutines)
+                api(libs.kotlinCoroutines)
             }
         }
         commonTest {

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslBehaviourTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslBehaviourTest.kt
@@ -43,7 +43,7 @@ internal class SimpleDslBehaviourTest {
         BaseDslMiddleware(this).test(this, initialState) {
             expectInitialState()
 
-            this.containerHost.reducer(action)
+            containerHost.reducer(action)
 
             expectState { TestState(action) }
         }
@@ -55,7 +55,7 @@ internal class SimpleDslBehaviourTest {
         BaseDslMiddleware(this).test(this, initialState) {
             expectInitialState()
 
-            this.containerHost.transformer(action)
+            containerHost.transformer(action)
 
             expectState { TestState(action + 5) }
         }
@@ -67,7 +67,7 @@ internal class SimpleDslBehaviourTest {
         BaseDslMiddleware(this).test(this, initialState) {
             expectInitialState()
 
-            this.containerHost.postingSideEffect(action)
+            containerHost.postingSideEffect(action)
 
             expectSideEffect(action.toString())
         }

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslBehaviourTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslBehaviourTest.kt
@@ -43,7 +43,7 @@ internal class SimpleDslBehaviourTest {
         BaseDslMiddleware(this).test(this, initialState) {
             expectInitialState()
 
-            invokeIntent { reducer(action) }
+            this.containerHost.reducer(action)
 
             expectState { TestState(action) }
         }
@@ -55,7 +55,7 @@ internal class SimpleDslBehaviourTest {
         BaseDslMiddleware(this).test(this, initialState) {
             expectInitialState()
 
-            invokeIntent { transformer(action) }
+            this.containerHost.transformer(action)
 
             expectState { TestState(action + 5) }
         }
@@ -67,7 +67,7 @@ internal class SimpleDslBehaviourTest {
         BaseDslMiddleware(this).test(this, initialState) {
             expectInitialState()
 
-            invokeIntent { postingSideEffect(action) }
+            this.containerHost.postingSideEffect(action)
 
             expectSideEffect(action.toString())
         }

--- a/orbit-test/orbit-test_build.gradle.kts
+++ b/orbit-test/orbit-test_build.gradle.kts
@@ -35,8 +35,8 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(kotlin("test-common"))
-                implementation(libs.kotlinCoroutines)
-                implementation(libs.kotlinCoroutinesTest)
+                api(libs.kotlinCoroutines)
+                api(libs.kotlinCoroutinesTest)
                 implementation(libs.turbine)
 
                 api(project(":orbit-core"))

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
@@ -31,6 +31,7 @@ public interface OrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST
     /**
      * Invoke an intent on the [ContainerHost] under test.
      */
+    @Deprecated("Use containerHost instead", ReplaceWith("action(containerHost)"))
     public fun invokeIntent(action: CONTAINER_HOST.() -> Job): Job
 
     /**

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
@@ -21,6 +21,8 @@ import org.orbitmvi.orbit.ContainerHost
 
 public interface OrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>> {
 
+    public val containerHost: CONTAINER_HOST
+
     /**
      * Invoke `onCreate` lambda for the [ContainerHost].
      */

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/RealOrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/RealOrbitTestContext.kt
@@ -17,7 +17,6 @@
 package org.orbitmvi.orbit.test
 
 import app.cash.turbine.ReceiveTurbine
-import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.Job
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitExperimental
@@ -31,26 +30,19 @@ public class RealOrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST
     initialState: STATE?,
     private val emissions: ReceiveTurbine<Item<STATE, SIDE_EFFECT>>
 ) : OrbitTestContext<STATE, SIDE_EFFECT, CONTAINER_HOST> {
-
-    private val onCreateAllowed = atomic(true)
-
     private val resolvedInitialState: STATE by lazy { initialState ?: containerHost.container.findTestContainer().originalInitialState }
     private var currentConsumedState: STATE = resolvedInitialState
 
     @OptIn(OrbitInternal::class)
     override fun runOnCreate(): Job {
-        if (onCreateAllowed.compareAndSet(expect = true, update = false)) {
-            val onCreate = containerHost.container.findOnCreate()
-            return runBlocking {
-                containerHost.container.orbit(onCreate)
-            }
-        } else {
-            error("runOnCreate should only be invoked once and before any invokeIntent call")
+        val onCreate = containerHost.container.findOnCreate()
+        return runBlocking {
+            containerHost.container.orbit(onCreate)
         }
     }
 
+    @Deprecated("Use containerHost instead", replaceWith = ReplaceWith("action(containerHost)"))
     override fun invokeIntent(action: CONTAINER_HOST.() -> Job): Job {
-        onCreateAllowed.lazySet(false)
         return containerHost.action()
     }
 

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/RealOrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/RealOrbitTestContext.kt
@@ -27,23 +27,22 @@ import kotlin.test.assertEquals
 import kotlin.test.fail
 
 public class RealOrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : ContainerHost<STATE, SIDE_EFFECT>>(
-    private val actual: CONTAINER_HOST,
+    override val containerHost: CONTAINER_HOST,
     initialState: STATE?,
     private val emissions: ReceiveTurbine<Item<STATE, SIDE_EFFECT>>
 ) : OrbitTestContext<STATE, SIDE_EFFECT, CONTAINER_HOST> {
 
     private val onCreateAllowed = atomic(true)
 
-    private val resolvedInitialState: STATE by lazy { initialState ?: actual.container.findTestContainer().originalInitialState }
-
+    private val resolvedInitialState: STATE by lazy { initialState ?: containerHost.container.findTestContainer().originalInitialState }
     private var currentConsumedState: STATE = resolvedInitialState
 
     @OptIn(OrbitInternal::class)
     override fun runOnCreate(): Job {
         if (onCreateAllowed.compareAndSet(expect = true, update = false)) {
-            val onCreate = actual.container.findOnCreate()
+            val onCreate = containerHost.container.findOnCreate()
             return runBlocking {
-                actual.container.orbit(onCreate)
+                containerHost.container.orbit(onCreate)
             }
         } else {
             error("runOnCreate should only be invoked once and before any invokeIntent call")
@@ -52,7 +51,7 @@ public class RealOrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST
 
     override fun invokeIntent(action: CONTAINER_HOST.() -> Job): Job {
         onCreateAllowed.lazySet(false)
-        return actual.action()
+        return containerHost.action()
     }
 
     override suspend fun awaitItem(): Item<STATE, SIDE_EFFECT> {
@@ -74,7 +73,7 @@ public class RealOrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST
     @OptIn(OrbitExperimental::class)
     override suspend fun cancelAndIgnoreRemainingItems() {
         emissions.cancelAndIgnoreRemainingEvents()
-        actual.container.cancel()
+        containerHost.container.cancel()
     }
 
     override suspend fun expectInitialState() {

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
@@ -38,7 +38,7 @@ class ExceptionTest {
                 ExceptionTestMiddleware(this).test(this) {
                     expectInitialState()
 
-                    val job = invokeIntent { boom() }
+                    val job = this.containerHost.boom()
 
                     job.join()
                 }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
@@ -38,7 +38,7 @@ class ExceptionTest {
                 ExceptionTestMiddleware(this).test(this) {
                     expectInitialState()
 
-                    val job = this.containerHost.boom()
+                    val job = containerHost.boom()
 
                     job.join()
                 }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InfiniteFlowTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InfiniteFlowTest.kt
@@ -39,7 +39,7 @@ internal class InfiniteFlowTest {
         InfiniteFlowMiddleware(this).test(this) {
             expectInitialState()
 
-            invokeIntent { incrementForever() }
+            this.containerHost.incrementForever()
 
             // Assert the first three states
             assertEquals(listOf(42, 43), awaitState())
@@ -57,7 +57,7 @@ internal class InfiniteFlowTest {
         InfiniteFlowMiddleware(this).test(scope) {
             expectInitialState()
 
-            val job = invokeIntent { incrementForever() }
+            val job = this.containerHost.incrementForever()
 
             // Assert the first three states
             scope.advanceTimeBy(3001)

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InfiniteFlowTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InfiniteFlowTest.kt
@@ -39,7 +39,7 @@ internal class InfiniteFlowTest {
         InfiniteFlowMiddleware(this).test(this) {
             expectInitialState()
 
-            this.containerHost.incrementForever()
+            containerHost.incrementForever()
 
             // Assert the first three states
             assertEquals(listOf(42, 43), awaitState())
@@ -57,7 +57,7 @@ internal class InfiniteFlowTest {
         InfiniteFlowMiddleware(this).test(scope) {
             expectInitialState()
 
-            val job = this.containerHost.incrementForever()
+            val job = containerHost.incrementForever()
 
             // Assert the first three states
             scope.advanceTimeBy(3001)

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/IntentJobsTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/IntentJobsTest.kt
@@ -43,7 +43,7 @@ class IntentJobsTest {
                 IntentJobsMiddleware(this).test(this) {
                     expectInitialState()
 
-                    this.containerHost.infiniteIntent()
+                    containerHost.infiniteIntent()
                 }
             }
         }
@@ -54,7 +54,7 @@ class IntentJobsTest {
         IntentJobsMiddleware(this).test(this) {
             expectInitialState()
 
-            this.containerHost.infiniteIntent()
+            containerHost.infiniteIntent()
             cancelAndIgnoreRemainingItems()
         }
     }
@@ -64,7 +64,7 @@ class IntentJobsTest {
         IntentJobsMiddleware(this).test(this) {
             expectInitialState()
 
-            val job = this.containerHost.infiniteIntent()
+            val job = containerHost.infiniteIntent()
 
             job.cancel()
         }
@@ -76,7 +76,7 @@ class IntentJobsTest {
         IntentJobsMiddleware(this).test(scope) {
             expectInitialState()
 
-            val job = this.containerHost.longIntent()
+            val job = containerHost.longIntent()
 
             scope.testScheduler.advanceTimeBy(300)
 

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/IntentJobsTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/IntentJobsTest.kt
@@ -43,7 +43,7 @@ class IntentJobsTest {
                 IntentJobsMiddleware(this).test(this) {
                     expectInitialState()
 
-                    invokeIntent { infiniteIntent() }
+                    this.containerHost.infiniteIntent()
                 }
             }
         }
@@ -54,7 +54,7 @@ class IntentJobsTest {
         IntentJobsMiddleware(this).test(this) {
             expectInitialState()
 
-            invokeIntent { infiniteIntent() }
+            this.containerHost.infiniteIntent()
             cancelAndIgnoreRemainingItems()
         }
     }
@@ -64,7 +64,7 @@ class IntentJobsTest {
         IntentJobsMiddleware(this).test(this) {
             expectInitialState()
 
-            val job = invokeIntent { infiniteIntent() }
+            val job = this.containerHost.infiniteIntent()
 
             job.cancel()
         }
@@ -76,7 +76,7 @@ class IntentJobsTest {
         IntentJobsMiddleware(this).test(scope) {
             expectInitialState()
 
-            val job = invokeIntent { longIntent() }
+            val job = this.containerHost.longIntent()
 
             scope.testScheduler.advanceTimeBy(300)
 

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
@@ -42,10 +42,10 @@ class ItemsTest {
 
         ItemTestMiddleware(this).test(this) {
             expectInitialState()
-            this.containerHost.newState(state1)
-            this.containerHost.newSideEffect(sideEffect1)
-            this.containerHost.newState(state2)
-            this.containerHost.newSideEffect(sideEffect2)
+            containerHost.newState(state1)
+            containerHost.newSideEffect(sideEffect1)
+            containerHost.newState(state2)
+            containerHost.newSideEffect(sideEffect2)
 
             skipItems(3)
             assertEquals(4, awaitSideEffect())
@@ -61,10 +61,10 @@ class ItemsTest {
 
         ItemTestMiddleware(this).test(this) {
             expectInitialState()
-            this.containerHost.newState(state1)
-            this.containerHost.newSideEffect(sideEffect1)
-            this.containerHost.newState(state2)
-            this.containerHost.newSideEffect(sideEffect2)
+            containerHost.newState(state1)
+            containerHost.newSideEffect(sideEffect1)
+            containerHost.newState(state2)
+            containerHost.newSideEffect(sideEffect2)
 
             assertEquals(Item.StateItem(State(1)), awaitItem())
             assertEquals(Item.SideEffectItem(3), awaitItem())

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
@@ -42,10 +42,10 @@ class ItemsTest {
 
         ItemTestMiddleware(this).test(this) {
             expectInitialState()
-            invokeIntent { newState(state1) }
-            invokeIntent { newSideEffect(sideEffect1) }
-            invokeIntent { newState(state2) }
-            invokeIntent { newSideEffect(sideEffect2) }
+            this.containerHost.newState(state1)
+            this.containerHost.newSideEffect(sideEffect1)
+            this.containerHost.newState(state2)
+            this.containerHost.newSideEffect(sideEffect2)
 
             skipItems(3)
             assertEquals(4, awaitSideEffect())
@@ -61,10 +61,10 @@ class ItemsTest {
 
         ItemTestMiddleware(this).test(this) {
             expectInitialState()
-            invokeIntent { newState(state1) }
-            invokeIntent { newSideEffect(sideEffect1) }
-            invokeIntent { newState(state2) }
-            invokeIntent { newSideEffect(sideEffect2) }
+            this.containerHost.newState(state1)
+            this.containerHost.newSideEffect(sideEffect1)
+            this.containerHost.newState(state2)
+            this.containerHost.newSideEffect(sideEffect2)
 
             assertEquals(Item.StateItem(State(1)), awaitItem())
             assertEquals(Item.SideEffectItem(3), awaitItem())

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
@@ -37,7 +37,7 @@ class RepeatOnSubscriptionTest {
         TestMiddleware(this).test(this, initialState = initialState) {
             expectInitialState()
 
-            invokeIntent { callOnSubscription { 42 } }
+            this.containerHost.callOnSubscription { 42 }
 
             assertEquals(State(42), awaitState())
         }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/RepeatOnSubscriptionTest.kt
@@ -37,7 +37,7 @@ class RepeatOnSubscriptionTest {
         TestMiddleware(this).test(this, initialState = initialState) {
             expectInitialState()
 
-            this.containerHost.callOnSubscription { 42 }
+            containerHost.callOnSubscription { 42 }
 
             assertEquals(State(42), awaitState())
         }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
@@ -40,7 +40,7 @@ class SideEffectTest {
         val sideEffects = List(Random.nextInt(1, 5)) { Random.nextInt() }
 
         SideEffectTestMiddleware(this).test(this) {
-            sideEffects.forEach { invokeIntent { something(it) } }
+            sideEffects.forEach { this.containerHost.something(it) }
 
             expectInitialState()
 
@@ -60,7 +60,7 @@ class SideEffectTest {
         val sideEffects = List(Random.nextInt(1, 5)) { Random.nextInt() }
 
         SideEffectTestMiddleware(this).test(this) {
-            sideEffects.forEach { invokeIntent { something(it) } }
+            sideEffects.forEach { this.containerHost.something(it) }
 
             expectInitialState()
 
@@ -77,7 +77,7 @@ class SideEffectTest {
 
         assertFailsWith<AssertionError> {
             SideEffectTestMiddleware(this).test(this) {
-                sideEffects.forEach { invokeIntent { something(it) } }
+                sideEffects.forEach { this.containerHost.something(it) }
 
                 expectInitialState()
                 assertEquals(
@@ -100,8 +100,8 @@ class SideEffectTest {
 
         assertFailsWith<AssertionError> {
             SideEffectTestMiddleware(this).test(this) {
-                invokeIntent { newState(sideEffect) }
-                invokeIntent { something(sideEffect) }
+                this.containerHost.newState(sideEffect)
+                this.containerHost.something(sideEffect)
 
                 expectInitialState()
                 awaitSideEffect()

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/SideEffectTest.kt
@@ -40,7 +40,7 @@ class SideEffectTest {
         val sideEffects = List(Random.nextInt(1, 5)) { Random.nextInt() }
 
         SideEffectTestMiddleware(this).test(this) {
-            sideEffects.forEach { this.containerHost.something(it) }
+            sideEffects.forEach { containerHost.something(it) }
 
             expectInitialState()
 
@@ -60,7 +60,7 @@ class SideEffectTest {
         val sideEffects = List(Random.nextInt(1, 5)) { Random.nextInt() }
 
         SideEffectTestMiddleware(this).test(this) {
-            sideEffects.forEach { this.containerHost.something(it) }
+            sideEffects.forEach { containerHost.something(it) }
 
             expectInitialState()
 
@@ -77,7 +77,7 @@ class SideEffectTest {
 
         assertFailsWith<AssertionError> {
             SideEffectTestMiddleware(this).test(this) {
-                sideEffects.forEach { this.containerHost.something(it) }
+                sideEffects.forEach { containerHost.something(it) }
 
                 expectInitialState()
                 assertEquals(
@@ -100,8 +100,8 @@ class SideEffectTest {
 
         assertFailsWith<AssertionError> {
             SideEffectTestMiddleware(this).test(this) {
-                this.containerHost.newState(sideEffect)
-                this.containerHost.something(sideEffect)
+                containerHost.newState(sideEffect)
+                containerHost.something(sideEffect)
 
                 expectInitialState()
                 awaitSideEffect()

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
@@ -62,8 +62,8 @@ class StateTest {
 
         StateTestMiddleware(this).test(this) {
             expectInitialState()
-            invokeIntent { newCount(action) }
-            invokeIntent { newCount(action2) }
+            this.containerHost.newCount(action)
+            this.containerHost.newCount(action2)
             assertEquals(State(count = action), awaitState())
             assertEquals(State(count = action2), awaitState())
         }
@@ -78,9 +78,9 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                invokeIntent { newCount(action) }
-                invokeIntent { newCount(action2) }
-                invokeIntent { newCount(action3) }
+                this.containerHost.newCount(action)
+                this.containerHost.newCount(action2)
+                this.containerHost.newCount(action3)
                 assertEquals(State(count = action), awaitState())
                 assertEquals(State(count = action2), awaitState())
             }
@@ -98,8 +98,8 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                invokeIntent { newCount(action) }
-                invokeIntent { newCount(action2) }
+                this.containerHost.newCount(action)
+                this.containerHost.newCount(action2)
                 assertEquals(State(count = action), awaitState())
                 assertEquals(State(count = action2), awaitState())
                 assertEquals(State(count = action3), awaitState())
@@ -118,8 +118,8 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                invokeIntent { newCount(action) }
-                invokeIntent { newCount(action2) }
+                this.containerHost.newCount(action)
+                this.containerHost.newCount(action2)
                 assertEquals(State(count = action2), awaitState())
                 assertEquals(State(count = action3), awaitState())
             }
@@ -137,8 +137,8 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                invokeIntent { newCount(action) }
-                invokeIntent { newCount(action2) }
+                this.containerHost.newCount(action)
+                this.containerHost.newCount(action2)
                 assertEquals(State(count = action), awaitState())
                 assertEquals(State(count = action3), awaitState())
             }
@@ -156,9 +156,9 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                invokeIntent { newCount(action) }
-                invokeIntent { newCount(action2) }
-                invokeIntent { newCount(action3) }
+                this.containerHost.newCount(action)
+                this.containerHost.newCount(action2)
+                this.containerHost.newCount(action3)
                 assertEquals(State(count = action), awaitState())
                 assertEquals(State(count = action3), awaitState())
                 assertEquals(State(count = action2), awaitState())
@@ -174,8 +174,8 @@ class StateTest {
 
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
-                invokeIntent { newSideEffect(sideEffect) }
-                invokeIntent { newCount(sideEffect) }
+                this.containerHost.newSideEffect(sideEffect)
+                this.containerHost.newCount(sideEffect)
 
                 expectInitialState()
                 awaitState()
@@ -194,9 +194,9 @@ class StateTest {
 
         StateTestMiddleware(this).test(this) {
             expectInitialState()
-            invokeIntent { newList(action) }
-            invokeIntent { newList(action2) }
-            invokeIntent { newList(action3) }
+            this.containerHost.newList(action)
+            this.containerHost.newList(action2)
+            this.containerHost.newList(action3)
             expectState { copy(list = listOf(action)) }
             expectState { copy(list = listOf(action, action2)) }
             expectState { copy(list = listOf(action, action2, action3)) }
@@ -211,9 +211,9 @@ class StateTest {
 
         StateTestMiddleware(this).test(this) {
             expectInitialState()
-            invokeIntent { newList(action) }
-            invokeIntent { newList(action2) }
-            invokeIntent { newList(action3) }
+            this.containerHost.newList(action)
+            this.containerHost.newList(action2)
+            this.containerHost.newList(action3)
             expectState(State(count = initialState.count, list = listOf(action)))
             expectState(State(count = initialState.count, list = listOf(action, action2)))
             expectState(State(count = initialState.count, list = listOf(action, action2, action3)))
@@ -229,9 +229,9 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                invokeIntent { newList(action) }
-                invokeIntent { newList(action2) }
-                invokeIntent { newList(action3) }
+                this.containerHost.newList(action)
+                this.containerHost.newList(action2)
+                this.containerHost.newList(action3)
                 expectState { copy(list = listOf(action)) }
                 expectState { copy(list = listOf(action, action2, action3)) }
                 expectState { copy(list = listOf(action, action2)) }
@@ -248,9 +248,9 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                invokeIntent { newList(action) }
-                invokeIntent { newList(action2) }
-                invokeIntent { newList(action3) }
+                this.containerHost.newList(action)
+                this.containerHost.newList(action2)
+                this.containerHost.newList(action3)
                 expectState(State(count = initialState.count, list = listOf(action)))
                 expectState(State(count = initialState.count, list = listOf(action, action2, action3)))
                 expectState(State(count = initialState.count, list = listOf(action, action2)))

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/StateTest.kt
@@ -62,8 +62,8 @@ class StateTest {
 
         StateTestMiddleware(this).test(this) {
             expectInitialState()
-            this.containerHost.newCount(action)
-            this.containerHost.newCount(action2)
+            containerHost.newCount(action)
+            containerHost.newCount(action2)
             assertEquals(State(count = action), awaitState())
             assertEquals(State(count = action2), awaitState())
         }
@@ -78,9 +78,9 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                this.containerHost.newCount(action)
-                this.containerHost.newCount(action2)
-                this.containerHost.newCount(action3)
+                containerHost.newCount(action)
+                containerHost.newCount(action2)
+                containerHost.newCount(action3)
                 assertEquals(State(count = action), awaitState())
                 assertEquals(State(count = action2), awaitState())
             }
@@ -98,8 +98,8 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                this.containerHost.newCount(action)
-                this.containerHost.newCount(action2)
+                containerHost.newCount(action)
+                containerHost.newCount(action2)
                 assertEquals(State(count = action), awaitState())
                 assertEquals(State(count = action2), awaitState())
                 assertEquals(State(count = action3), awaitState())
@@ -118,8 +118,8 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                this.containerHost.newCount(action)
-                this.containerHost.newCount(action2)
+                containerHost.newCount(action)
+                containerHost.newCount(action2)
                 assertEquals(State(count = action2), awaitState())
                 assertEquals(State(count = action3), awaitState())
             }
@@ -137,8 +137,8 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                this.containerHost.newCount(action)
-                this.containerHost.newCount(action2)
+                containerHost.newCount(action)
+                containerHost.newCount(action2)
                 assertEquals(State(count = action), awaitState())
                 assertEquals(State(count = action3), awaitState())
             }
@@ -156,9 +156,9 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                this.containerHost.newCount(action)
-                this.containerHost.newCount(action2)
-                this.containerHost.newCount(action3)
+                containerHost.newCount(action)
+                containerHost.newCount(action2)
+                containerHost.newCount(action3)
                 assertEquals(State(count = action), awaitState())
                 assertEquals(State(count = action3), awaitState())
                 assertEquals(State(count = action2), awaitState())
@@ -174,8 +174,8 @@ class StateTest {
 
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
-                this.containerHost.newSideEffect(sideEffect)
-                this.containerHost.newCount(sideEffect)
+                containerHost.newSideEffect(sideEffect)
+                containerHost.newCount(sideEffect)
 
                 expectInitialState()
                 awaitState()
@@ -194,9 +194,9 @@ class StateTest {
 
         StateTestMiddleware(this).test(this) {
             expectInitialState()
-            this.containerHost.newList(action)
-            this.containerHost.newList(action2)
-            this.containerHost.newList(action3)
+            containerHost.newList(action)
+            containerHost.newList(action2)
+            containerHost.newList(action3)
             expectState { copy(list = listOf(action)) }
             expectState { copy(list = listOf(action, action2)) }
             expectState { copy(list = listOf(action, action2, action3)) }
@@ -211,9 +211,9 @@ class StateTest {
 
         StateTestMiddleware(this).test(this) {
             expectInitialState()
-            this.containerHost.newList(action)
-            this.containerHost.newList(action2)
-            this.containerHost.newList(action3)
+            containerHost.newList(action)
+            containerHost.newList(action2)
+            containerHost.newList(action3)
             expectState(State(count = initialState.count, list = listOf(action)))
             expectState(State(count = initialState.count, list = listOf(action, action2)))
             expectState(State(count = initialState.count, list = listOf(action, action2, action3)))
@@ -229,9 +229,9 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                this.containerHost.newList(action)
-                this.containerHost.newList(action2)
-                this.containerHost.newList(action3)
+                containerHost.newList(action)
+                containerHost.newList(action2)
+                containerHost.newList(action3)
                 expectState { copy(list = listOf(action)) }
                 expectState { copy(list = listOf(action, action2, action3)) }
                 expectState { copy(list = listOf(action, action2)) }
@@ -248,9 +248,9 @@ class StateTest {
         assertFailsWith<AssertionError> {
             StateTestMiddleware(this).test(this) {
                 expectInitialState()
-                this.containerHost.newList(action)
-                this.containerHost.newList(action2)
-                this.containerHost.newList(action3)
+                containerHost.newList(action)
+                containerHost.newList(action2)
+                containerHost.newList(action3)
                 expectState(State(count = initialState.count, list = listOf(action)))
                 expectState(State(count = initialState.count, list = listOf(action, action2, action3)))
                 expectState(State(count = initialState.count, list = listOf(action, action2)))

--- a/orbit-viewmodel/orbit-viewmodel_build.gradle.kts
+++ b/orbit-viewmodel/orbit-viewmodel_build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     api(project(":orbit-core"))
 
     implementation(libs.androidxLifecycleSavedState)
-    implementation(libs.androidxLifecycleViewmodelKtx)
+    api(libs.androidxLifecycleViewmodelKtx)
     implementation(libs.androidxLifecycleRuntimeKtx)
     implementation(libs.androidxEspressoIdlingResource)
 

--- a/website/docs/Test/new.md
+++ b/website/docs/Test/new.md
@@ -310,9 +310,15 @@ val container = scope.container<SomeState, Unit> {
 ```
 
 A good practice is to replace the infinite flow with a finite flow for the test.
-This helps keep the test simple. If this is not possible, we have to make
-sure we disregard extra states and side effects that are emitted at the end
-of the test by calling `cancelAndIgnoreRemainingItems()`.
+This helps keep the test simple. 
+
+If this is not possible or desirable, we may run the intent collecting the
+infinite flow as normal and `join()` the `Job` returned by the intent to ensure
+it is completed at the end of the test. 
+
+Our last resort is calling `cancelAndIgnoreRemainingItems()` to cancel the scope
+and disregard any extra states and side effects that are emitted at the end
+of the test.
 
 Otherwise, testing a container that subscribes to an infinite flow is no
 different to normal testing.
@@ -333,7 +339,7 @@ fun exampleTest() = runTest {
             
             // If the flow is infinite, we must ensure the intent is finished
             // at the end of the test.
-            job.join
+            job.join()
             // OR
             cancelAndIgnoreRemainingItems()
         }

--- a/website/docs/Test/new.md
+++ b/website/docs/Test/new.md
@@ -105,7 +105,7 @@ set a correct initial state instead.
 @Test
 fun exampleTest() = runTest {
         ExampleViewModel().test(this) {
-            runOnCreate() // may be invoked only once and before `invokeIntent`
+            runOnCreate()
             expectInitialState()
             containerHost.countToFour()
         }


### PR DESCRIPTION
Fixes for:

* https://github.com/orbit-mvi/orbit-mvi/issues/177
* https://github.com/orbit-mvi/orbit-mvi/issues/179
* https://github.com/orbit-mvi/orbit-mvi/issues/180

Blocking intents and other container host functions can be called via `containerHost.xxx()` directly.

I'm removing `invokeIntent` to keep things consistent cc @mattmook , see discussion at https://github.com/orbit-mvi/orbit-mvi/issues/180 . TL;DR is that this change will allow people not to expose `Job` from their `ContainerHost` if they don't need it in tests - I think this is the solution we missed originally.