### PR TITLE
Add expectNoItems to OrbitTestContext

### DIFF
--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestContext.kt
@@ -69,6 +69,13 @@ public interface OrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST
     public suspend fun expectSideEffect(expected: SIDE_EFFECT)
 
     /**
+     * Assert there are no unconsumed items
+     *
+     * @throws AssertionError if unconsumed items are found
+     */
+    public suspend fun expectNoItems()
+
+    /**
      * Return the next item received.
      * This function will suspend if no items have been received.
      */

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/RealOrbitTestContext.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/RealOrbitTestContext.kt
@@ -89,6 +89,10 @@ public class RealOrbitTestContext<STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST
         assertEquals(expected, awaitSideEffect())
     }
 
+    override suspend fun expectNoItems() {
+        emissions.expectNoEvents()
+    }
+
     override suspend fun expectState(expectedChange: STATE.() -> STATE) {
         assertEquals(expectedChange(currentConsumedState), awaitState())
     }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsTest.kt
@@ -27,6 +27,8 @@ import org.orbitmvi.orbit.syntax.simple.reduce
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.fail
 
 @ExperimentalCoroutinesApi
 class ItemsTest {
@@ -70,6 +72,21 @@ class ItemsTest {
             assertEquals(Item.SideEffectItem(3), awaitItem())
             assertEquals(Item.StateItem(State(2)), awaitItem())
             assertEquals(Item.SideEffectItem(4), awaitItem())
+        }
+    }
+
+    @Test
+    fun `correctly expects no items`() = runTest {
+        ItemTestMiddleware(this).test(this) {
+            expectInitialState()
+            expectNoItems()
+        }
+    }
+
+    @Test
+    fun `expects no items fails when there are unconsumed items`() = runTest {
+        ItemTestMiddleware(this).test(this) {
+            assertFails { expectNoItems() }
         }
     }
 


### PR DESCRIPTION
This can be useful, for example, for expecting that some condition resulted in a side effect not being called