### PR TITLE
Allow configuring eventloop & intent dispatchers

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
@@ -26,6 +26,18 @@ public class SettingsBuilder {
             settings = settings.copy(idlingRegistry = value)
         }
 
+    public var eventLoopDispatcher: CoroutineDispatcher
+        get() = settings.eventLoopDispatcher
+        public set(value) {
+            settings = settings.copy(eventLoopDispatcher = value)
+        }
+
+    public var intentLaunchingDispatcher: CoroutineDispatcher
+        get() = settings.intentLaunchingDispatcher
+        public set(value) {
+            settings = settings.copy(intentLaunchingDispatcher = value)
+        }
+
     public var exceptionHandler: CoroutineExceptionHandler?
         get() = settings.exceptionHandler
         public set(value) {


### PR DESCRIPTION
This is useful for injecting test dispatchers while unit testing. It was there in orbit `4.2.0` and my current org uses it heavily. It mostly looks like a miss when orbit-mvi migrated to `SettingsBuilder`