### PR TITLE
Fix repeatOnSubscription to take into account external subscribers only

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Mikołaj Leszczyński & Appmattus Limited
+# Copyright 2023-2024 Mikołaj Leszczyński & Appmattus Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = 
 # AndroidX
 androidxLifecycleSavedState = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidxLifecycles" }
 androidxLifecycleViewmodelKtx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidxLifecycles" }
+androidxLifecycleRuntimeCompose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycles" }
 androidxLifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidxLifecycles" }
 androidxEspressoIdlingResource = { module = "androidx.test.espresso:espresso-idling-resource", version.ref = "androidxEspresso" }
 androidxEspressoCore = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxEspresso" }

--- a/orbit-compose/orbit-compose_build.gradle.kts
+++ b/orbit-compose/orbit-compose_build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2024 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ dependencies {
     api(project(":orbit-core"))
 
     implementation(libs.androidxComposeRuntime)
+    implementation(libs.androidxLifecycleRuntimeCompose)
     implementation(libs.androidxLifecycleRuntimeKtx)
     implementation(libs.androidxComposeUi)
 

--- a/orbit-compose/src/test/kotlin/org/orbitmvi/orbit/compose/ContainerHostExtensionsKtTest.kt
+++ b/orbit-compose/src/test/kotlin/org/orbitmvi/orbit/compose/ContainerHostExtensionsKtTest.kt
@@ -41,6 +41,7 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.random.Random
 import kotlin.test.assertEquals
 
+@Suppress("DEPRECATION")
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 class ContainerHostExtensionsKtTest {

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerDecorator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2024 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,8 +42,12 @@ public interface ContainerDecorator<STATE : Any, SIDE_EFFECT : Any> : Container<
         get() = actual.settings
     override val stateFlow: StateFlow<STATE>
         get() = actual.stateFlow
+    override val refCountStateFlow: StateFlow<STATE>
+        get() = actual.refCountStateFlow
     override val sideEffectFlow: Flow<SIDE_EFFECT>
         get() = actual.sideEffectFlow
+    override val refCountSideEffectFlow: Flow<SIDE_EFFECT>
+        get() = actual.refCountSideEffectFlow
 
     override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit): Job {
         return actual.orbit(orbitIntent)

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022-2024 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.orbitmvi.orbit
 
 import kotlinx.coroutines.CoroutineDispatcher
@@ -13,7 +28,7 @@ public data class RealSettings(
     public val eventLoopDispatcher: CoroutineDispatcher = Dispatchers.Default,
     public val intentLaunchingDispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
     public val exceptionHandler: CoroutineExceptionHandler? = null,
-    public val repeatOnSubscribedStopTimeout: Long = 100L
+    public val repeatOnSubscribedStopTimeout: Long = 100L,
 )
 
 public class SettingsBuilder {

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/InterceptingContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/InterceptingContainerDecorator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2024 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
@@ -38,10 +38,14 @@ public class LazyCreateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
     private val created = atomic(false)
 
     override val stateFlow: StateFlow<STATE> = actual.stateFlow.onSubscribe { runOnCreate() }
-
+    override val refCountStateFlow: StateFlow<STATE> = actual.refCountStateFlow.onSubscribe { runOnCreate() }
     override val sideEffectFlow: Flow<SIDE_EFFECT> = flow {
         runOnCreate()
         emitAll(actual.sideEffectFlow)
+    }
+    override val refCountSideEffectFlow: Flow<SIDE_EFFECT> = flow {
+        runOnCreate()
+        emitAll(actual.refCountSideEffectFlow)
     }
 
     private fun runOnCreate() {

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2024 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +43,12 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
 
     override val stateFlow: StateFlow<STATE>
         get() = delegate.value.stateFlow
-
+    override val refCountStateFlow: StateFlow<STATE>
+        get() = delegate.value.refCountStateFlow
     override val sideEffectFlow: Flow<SIDE_EFFECT>
         get() = delegate.value.sideEffectFlow
+    override val refCountSideEffectFlow: Flow<SIDE_EFFECT>
+        get() = delegate.value.refCountSideEffectFlow
 
     override suspend fun orbit(orbitIntent: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit): Job {
         return delegate.value.orbit(orbitIntent)

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/DelayingSubscribedCounter.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/DelayingSubscribedCounter.kt
@@ -1,46 +1,57 @@
+/*
+ * Copyright 2021-2024 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.orbitmvi.orbit.internal.repeatonsubscription
 
 import kotlinx.atomicfu.atomic
-import kotlinx.atomicfu.getAndUpdate
+import kotlinx.atomicfu.updateAndGet
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription.Subscribed
 import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription.Unsubscribed
 
 internal class DelayingSubscribedCounter(
-    private val scope: CoroutineScope,
+    scope: CoroutineScope,
     private val repeatOnSubscribedStopTimeout: Long
 ) : SubscribedCounter {
 
-    private val _subscribed: MutableStateFlow<Subscription> = MutableStateFlow(Unsubscribed)
+    private val _subscribed: Channel<Subscription> = Channel(Channel.BUFFERED)
 
-    override val subscribed: Flow<Subscription> = _subscribed.asStateFlow()
+    @OptIn(FlowPreview::class)
+    override val subscribed: Flow<Subscription> = _subscribed
+        .receiveAsFlow()
+        .debounce { if (it == Unsubscribed) repeatOnSubscribedStopTimeout else 0 }
+        .stateIn(scope, started = SharingStarted.Eagerly, initialValue = Unsubscribed)
 
     private val counter = atomic(0)
-    private var mutex = Mutex()
-    private val job = atomic<Job?>(null)
 
-    override suspend fun increment(): Unit = mutex.withLock {
+    override suspend fun increment() {
         counter.incrementAndGet()
-        job.getAndSet(null)?.cancel()
-        _subscribed.value = Subscribed
+        _subscribed.send(Subscribed)
     }
 
-    override suspend fun decrement(): Unit = mutex.withLock {
-        if (counter.getAndUpdate { if (it > 0) it - 1 else 0 } == 1) {
-            job.getAndSet(
-                scope.launch {
-                    delay(repeatOnSubscribedStopTimeout)
-                    _subscribed.value = Unsubscribed
-                }
-            )?.cancel()
+    override suspend fun decrement() {
+        if (counter.updateAndGet { if (it > 0) it - 1 else 0 } == 0) {
+            _subscribed.send(Unsubscribed)
         }
     }
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/SubscribedCounter.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/SubscribedCounter.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021-2024 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.orbitmvi.orbit.internal.repeatonsubscription
 
 import kotlinx.coroutines.flow.Flow

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleSyntaxExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleSyntaxExtensions.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitDsl
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.idling.withIdling
 import org.orbitmvi.orbit.internal.runBlocking
 import org.orbitmvi.orbit.syntax.ContainerContext

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountSideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountSideEffectTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * File modified by Mikołaj Leszczyński & Appmattus Limited
+ * See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
+ */
+
+package org.orbitmvi.orbit.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.container
+import org.orbitmvi.orbit.test.assertContainExactly
+import org.orbitmvi.orbit.test.assertNotContainExactly
+import org.orbitmvi.orbit.testFlowObserver
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@ExperimentalCoroutinesApi
+internal class RefCountSideEffectTest {
+
+    private val scope = CoroutineScope(Job())
+
+    @AfterTest
+    fun afterTest() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `side effects are emitted in order`() = runBlocking {
+        val container = scope.container<Unit, Int>(Unit)
+
+        val testSideEffectObserver1 = container.refCountSideEffectFlow.testFlowObserver()
+
+        repeat(1000) {
+            container.someFlow(it)
+        }
+
+        testSideEffectObserver1.awaitCount(1000)
+
+        testSideEffectObserver1.values.assertContainExactly((0..999).toList())
+    }
+
+    @Test
+    fun `side effects are not multicast`() = runBlocking {
+        val action = Random.nextInt()
+        val action2 = Random.nextInt()
+        val action3 = Random.nextInt()
+        val container = scope.container<Unit, Int>(Unit)
+
+        val testSideEffectObserver1 = container.refCountSideEffectFlow.testFlowObserver()
+        val testSideEffectObserver2 = container.refCountSideEffectFlow.testFlowObserver()
+        val testSideEffectObserver3 = container.refCountSideEffectFlow.testFlowObserver()
+
+        container.someFlow(action)
+        container.someFlow(action2)
+        container.someFlow(action3)
+
+        val timeout = 500L
+        testSideEffectObserver1.awaitCount(3, timeout)
+        testSideEffectObserver2.awaitCount(3, timeout)
+        testSideEffectObserver3.awaitCount(3, timeout)
+
+        testSideEffectObserver1.values.assertNotContainExactly(action, action2, action3)
+        testSideEffectObserver2.values.assertNotContainExactly(action, action2, action3)
+        testSideEffectObserver3.values.assertNotContainExactly(action, action2, action3)
+    }
+
+    @Test
+    fun `side effects are cached when there are no subscribers`() = runBlocking {
+        val action = Random.nextInt()
+        val action2 = Random.nextInt()
+        val action3 = Random.nextInt()
+        val container = scope.container<Unit, Int>(Unit)
+
+        container.someFlow(action)
+        container.someFlow(action2)
+        container.someFlow(action3)
+
+        val testSideEffectObserver1 = container.refCountSideEffectFlow.testFlowObserver()
+
+        testSideEffectObserver1.awaitCount(3)
+
+        testSideEffectObserver1.values.assertContainExactly(action, action2, action3)
+    }
+
+    @Test
+    fun `consumed side effects are not resent`() = runBlocking {
+        val action = Random.nextInt()
+        val action2 = Random.nextInt()
+        val action3 = Random.nextInt()
+        val container = scope.container<Unit, Int>(Unit)
+        val testSideEffectObserver1 = container.refCountSideEffectFlow.testFlowObserver()
+
+        container.someFlow(action)
+        container.someFlow(action2)
+        container.someFlow(action3)
+        testSideEffectObserver1.awaitCount(3)
+        testSideEffectObserver1.close()
+
+        val testSideEffectObserver2 = container.refCountSideEffectFlow.testFlowObserver()
+
+        testSideEffectObserver1.awaitCount(3, 10L)
+
+        assertEquals(0, testSideEffectObserver2.values.size, "should be empty")
+    }
+
+    @Test
+    fun `only new side effects are emitted when resubscribing`() = runBlocking {
+        val action = Random.nextInt()
+        val container = scope.container<Unit, Int>(Unit)
+
+        val testSideEffectObserver1 = container.refCountSideEffectFlow.testFlowObserver()
+
+        container.someFlow(action)
+
+        testSideEffectObserver1.awaitCount(1)
+        testSideEffectObserver1.close()
+
+        coroutineScope {
+            launch {
+                repeat(1000) {
+                    container.someFlow(it)
+                }
+            }
+        }
+
+        val testSideEffectObserver2 = container.refCountSideEffectFlow.testFlowObserver()
+        testSideEffectObserver2.awaitCount(1000)
+
+        testSideEffectObserver1.values.assertContainExactly(action)
+        testSideEffectObserver2.values.assertContainExactly((0..999).toList())
+    }
+
+    private suspend fun Container<Unit, Int>.someFlow(action: Int) = orbit {
+        postSideEffect(action)
+    }
+}

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountStateTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountStateTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * File modified by Mikołaj Leszczyński & Appmattus Limited
+ * See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
+ */
+
+package org.orbitmvi.orbit.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.container
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.test.assertContainExactly
+import org.orbitmvi.orbit.testFlowObserver
+import kotlin.random.Random
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@ExperimentalCoroutinesApi
+internal class RefCountStateTest {
+
+    private val scope = CoroutineScope(Job())
+
+    @AfterTest
+    fun afterTest() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `initial state is emitted on connection`() {
+        val initialState = TestState()
+        val middleware = Middleware(initialState)
+        val testStateObserver = middleware.container.refCountStateFlow.testFlowObserver()
+
+        testStateObserver.awaitCount(1)
+
+        testStateObserver.values.assertContainExactly(initialState)
+    }
+
+    @Test
+    fun `latest state is emitted on connection`() {
+        val initialState = TestState()
+        val middleware = Middleware(initialState)
+        val testStateObserver = middleware.container.refCountStateFlow.testFlowObserver()
+        val action = Random.nextInt()
+        middleware.something(action)
+        testStateObserver.awaitCount(2) // block until the state is updated
+
+        val testStateObserver2 = middleware.container.refCountStateFlow.testFlowObserver()
+        testStateObserver2.awaitCount(1)
+
+        testStateObserver.values.assertContainExactly(
+            initialState,
+            TestState(action)
+        )
+        testStateObserver2.values.assertContainExactly(
+            TestState(
+                action
+            )
+        )
+    }
+
+    @Test
+    fun `current state is set to the initial state after instantiation`() {
+        val initialState = TestState()
+        val middleware = Middleware(initialState)
+
+        assertEquals(initialState, middleware.container.refCountStateFlow.value)
+    }
+
+    @Test
+    fun `current state is up to date after modification`() {
+        val initialState = TestState()
+        val middleware = Middleware(initialState)
+        val action = Random.nextInt()
+        val testStateObserver = middleware.container.refCountStateFlow.testFlowObserver()
+
+        middleware.something(action)
+
+        testStateObserver.awaitCount(2)
+
+        assertEquals(testStateObserver.values.last(), middleware.container.refCountStateFlow.value)
+    }
+
+    private data class TestState(val id: Int = Random.nextInt())
+
+    private inner class Middleware(initialState: TestState) : ContainerHost<TestState, String> {
+        override val container = scope.container<TestState, String>(initialState)
+
+        fun something(action: Int) = intent {
+            reduce {
+                state.copy(id = action)
+            }
+        }
+    }
+}

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/RepeatOnSubscriptionTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/RepeatOnSubscriptionTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit.internal.repeatonsubscription
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.container
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.syntax.simple.repeatOnSubscription
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.time.Duration.Companion.milliseconds
+
+internal class RepeatOnSubscriptionTest {
+    private val initialState = State()
+
+    @Test
+    fun `block is not executed when there is no subscription to the ref count state flow`() = runTest {
+        val testSubject = TestMiddleware(this)
+
+        testSubject.container.stateFlow.test(timeout = 500.milliseconds) {
+            assertEquals(initialState, awaitItem())
+
+            val intentJob = testSubject.updateState { 42 }
+
+            assertFails { awaitItem() }
+            intentJob.cancel()
+        }
+    }
+
+    @Test
+    fun `block is executed when there is a subscription to the state flow`() = runTest {
+        val testSubject = TestMiddleware(this)
+
+        testSubject.container.refCountStateFlow.test {
+            assertEquals(initialState, awaitItem())
+
+            val intentJob = testSubject.updateState { 42 }
+
+            assertEquals(State(42), awaitItem())
+            intentJob.cancel()
+        }
+    }
+
+    @Test
+    fun `block is not executed when there is no subscription to the ref count side effect flow`() = runTest {
+        val testSubject = TestMiddleware(this)
+
+        testSubject.container.sideEffectFlow.test(timeout = 500.milliseconds) {
+            val intentJob = testSubject.updateSideEffect { 42 }
+
+            assertFails { awaitItem() }
+            intentJob.cancel()
+        }
+    }
+
+    @Test
+    fun `block is executed when there is a subscription to the ref count side effect flow`() = runTest {
+        val testSubject = TestMiddleware(this)
+
+        testSubject.container.refCountSideEffectFlow.test {
+            val intentJob = testSubject.updateSideEffect { 42 }
+
+            assertEquals(42, awaitItem())
+            intentJob.cancel()
+        }
+    }
+
+    private inner class TestMiddleware(testScope: TestScope) : ContainerHost<State, Int> {
+        override val container = testScope.backgroundScope.container<State, Int>(initialState)
+
+        fun updateState(externalCall: suspend () -> Int) = intent {
+            repeatOnSubscription {
+                val result = externalCall()
+                reduce { State(result) }
+            }
+        }
+
+        fun updateSideEffect(externalCall: suspend () -> Int) = intent {
+            repeatOnSubscription {
+                val result = externalCall()
+                postSideEffect(result)
+            }
+        }
+    }
+
+    private data class State(val count: Int = Random.nextInt())
+}

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/TestSubscribedCounter.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/repeatonsubscription/TestSubscribedCounter.kt
@@ -1,14 +1,33 @@
+/*
+ * Copyright 2021-2024 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * File modified by Mikołaj Leszczyński & Appmattus Limited
+ * See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
+ */
+
 package org.orbitmvi.orbit.internal.repeatonsubscription
 
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 internal class TestSubscribedCounter : SubscribedCounter {
     var counter = 0
 
     val flow = MutableStateFlow(Subscription.Unsubscribed)
-    override val subscribed: Flow<Subscription> = flow.asStateFlow()
+    override val subscribed: StateFlow<Subscription> = flow.asStateFlow()
 
     override suspend fun increment() {
         counter++

--- a/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/ContainerHostExtensions.kt
+++ b/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/ContainerHostExtensions.kt
@@ -49,8 +49,8 @@ fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.observe(
     lifecycleOwner.lifecycleScope.launch {
         // See https://medium.com/androiddevelopers/a-safer-way-to-collect-flows-from-android-uis-23080b1f8bda
         lifecycleOwner.lifecycle.repeatOnLifecycle(lifecycleState) {
-            state?.let { launch { container.stateFlow.collect { state(it) } } }
-            sideEffect?.let { launch { container.sideEffectFlow.collect { sideEffect(it) } } }
+            state?.let { launch { container.refCountStateFlow.collect { state(it) } } }
+            sideEffect?.let { launch { container.refCountSideEffectFlow.collect { sideEffect(it) } } }
         }
     }
 }


### PR DESCRIPTION
`repeatOnSubscription` is an API designed to repeat a block of code whenever the total number of subscribers to a Container's StateFlow + Side effect flow goes from 0 -> 1, and conversely - cancel this block's coroutine when it goes down to 0.

We have not taken into account that one could be subscribing to the Container's state updates within its `ContainerHost`. This causes a subscription that lasts until the scope is cancelled, so the `repeatOnSubscription` block is never cancelled , and thus, never repeated - even if all external subscribers (e.g. the UI) drop away.

To remediate this, we:

1. `stateFlow` and `sideEffectFlow` had their refcount operators removed. From now on, subscribing to these will not be taken into account for the subscriber count used in `repeatOnSubscription`
2. Added `refCountStateFlow` and `refCountSideEffectFlow` as ref-counted wrappers around `stateFlow` and `sideEffectFlow`. Under the hood they all originate from the same flows, but now one has to explicitly decide whether they want the ref-counted version or not.
3. The Compose extensions were updated to use `refCount` versions of the container's output.

The changes were done in a way to minimise potential breaking behaviour. However, if you are using `stateFlow` or `sideEffectFlow` directly and externally to `ContainerHost` (and not subscribing to container flows internally in the `ContainerHost`), it's worth considering updating these usages to `refCountStateFlow`.