### PR TITLE
Remove unconfined dispatcher from intent launch

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
@@ -11,7 +11,6 @@ public data class RealSettings(
     public val sideEffectBufferSize: Int = Channel.BUFFERED,
     public val idlingRegistry: IdlingResource = NoopIdlingResource(),
     public val eventLoopDispatcher: CoroutineDispatcher = Dispatchers.Default,
-    public val intentLaunchingDispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
     public val exceptionHandler: CoroutineExceptionHandler? = null,
     public val repeatOnSubscribedStopTimeout: Long = 100L
 )

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -24,6 +24,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -107,9 +108,8 @@ public class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
                 for ((job, intent) in dispatchChannel) {
                     val exceptionHandlerContext =
                         (settings.exceptionHandler?.plus(SupervisorJob(job)) ?: job) +
-                            settings.intentLaunchingDispatcher +
                             CoroutineName("$COROUTINE_NAME_INTENT${intentCounter.getAndIncrement()}")
-                    launch(exceptionHandlerContext) {
+                    launch(exceptionHandlerContext, start = CoroutineStart.UNDISPATCHED) {
                         pluginContext.intent()
                     }.invokeOnCompletion { job.complete() }
                 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleSyntaxExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleSyntaxExtensions.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.annotation.OrbitDsl
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.idling.withIdling
 import org.orbitmvi.orbit.internal.runBlocking
 import org.orbitmvi.orbit.syntax.ContainerContext

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/SettingsBuilder.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/SettingsBuilder.kt
@@ -13,7 +13,6 @@ public class TestSettingsBuilder internal constructor(
         UnconfinedTestDispatcher().let {
             RealSettings(
                 eventLoopDispatcher = it,
-                intentLaunchingDispatcher = it
             )
         }
     )
@@ -37,7 +36,6 @@ public class LiveTestSettingsBuilder internal constructor(
         UnconfinedTestDispatcher().let {
             RealSettings(
                 eventLoopDispatcher = it,
-                intentLaunchingDispatcher = it
             )
         }
     )
@@ -47,7 +45,6 @@ public class LiveTestSettingsBuilder internal constructor(
         public set(value) {
             settings = settings.copy(
                 eventLoopDispatcher = value,
-                intentLaunchingDispatcher = value
             )
         }
 

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Test.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Test.kt
@@ -79,7 +79,6 @@ private fun TestSettings.toRealSettings(testDispatcher: CoroutineDispatcher?): R
 
     return RealSettings(
         eventLoopDispatcher = dispatcher,
-        intentLaunchingDispatcher = dispatcher,
         exceptionHandler = exceptionHandlerOverride,
         repeatOnSubscribedStopTimeout = 0L
     )


### PR DESCRIPTION
Due to our use of the `Unconfined` dispatcher for launching intent coroutines off the Orbit event loop, we ran into cases where the continuation of some intents after re-subscription would resume on the `main` dispatcher. This is entirely unintended and has the potential to cause bugs like frame drops etc.

I found a way to keep the existing behaviour, but drop the unconfined dispatcher. Continuations should now resume in the dispatcher taken from the coroutine context. 