### PR TITLE
Fix state is not saved to SavedStateHandle

### DIFF
--- a/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/SavedStateContainerDecorator.kt
+++ b/orbit-viewmodel/src/main/kotlin/org/orbitmvi/orbit/viewmodel/SavedStateContainerDecorator.kt
@@ -35,4 +35,10 @@ internal class SavedStateContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
             savedStateHandle[SAVED_STATE_KEY] = it
         }
     }
+
+    override val refCountStateFlow: StateFlow<STATE> by lazy {
+        actual.refCountStateFlow.onEach {
+            savedStateHandle[SAVED_STATE_KEY] = it
+        }
+    }
 }

--- a/orbit-viewmodel/src/test/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensionsKtTest.kt
+++ b/orbit-viewmodel/src/test/kotlin/org/orbitmvi/orbit/viewmodel/ViewModelExtensionsKtTest.kt
@@ -75,6 +75,21 @@ class ViewModelExtensionsKtTest {
     }
 
     @Test
+    fun `Modified state is saved in the saved state handle for refCountStateFlow`() {
+        val initialState = TestState()
+        val something = Random.nextInt()
+        val savedStateHandle = SavedStateHandle()
+        val middleware = Middleware(savedStateHandle, initialState)
+        val testStateObserver = middleware.container.refCountStateFlow.testFlowObserver()
+
+        middleware.something(something)
+
+        testStateObserver.awaitCount(2)
+
+        assertEquals(TestState(something), savedStateHandle[SAVED_STATE_KEY])
+    }
+
+    @Test
     fun `When saved state is present calls onCreate with restored state`() = runTest {
         val initialState = TestState()
         val savedState = TestState()


### PR DESCRIPTION
In versions 7.0.0 to 7.1.1
When I use SavedStateHandle in ViewModel and collect state using Compose collectAsState, the state is not saved to SavedStateHandle.