### PR TITLE
Added container with ext state option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,6 +268,10 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# Kotlin multiplatform
+.kotlin/metadata/kotlinTransformedMetadataLibraries/
+kotlin-js-store/
+
 ### AndroidStudio Patch ###
 
 !/gradle/wrapper/gradle-wrapper.jar

--- a/orbit-compose/src/main/kotlin/org/orbitmvi/orbit/compose/ContainerHostExtensions.kt
+++ b/orbit-compose/src/main/kotlin/org/orbitmvi/orbit/compose/ContainerHostExtensions.kt
@@ -28,6 +28,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.ContainerHostWithExtState
+import org.orbitmvi.orbit.ContainerWithExtState
 import org.orbitmvi.orbit.syntax.simple.repeatOnSubscription
 
 /**
@@ -91,4 +93,20 @@ public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.co
     lifecycleState: Lifecycle.State = Lifecycle.State.STARTED
 ): State<STATE> {
     return container.refCountStateFlow.collectAsStateWithLifecycle(minActiveState = lifecycleState)
+}
+
+/**
+ * Observe the [ContainerWithExtState.extStateFlow] as [State].
+ *
+ * @param lifecycleState The minimum lifecycle state at which the state is observed.
+ *
+ * Active subscriptions from this operator count towards [repeatOnSubscription] subscribers.
+ */
+@Composable
+public fun <STATE : Any, SIDE_EFFECT : Any, UI_STATE : Any> ContainerHostWithExtState<
+    STATE,
+    SIDE_EFFECT,
+    UI_STATE,
+    >.collectExtState(lifecycleState: Lifecycle.State = androidx.lifecycle.Lifecycle.State.STARTED): State<UI_STATE> {
+    return container.extStateFlow.collectAsStateWithLifecycle(minActiveState = lifecycleState)
 }

--- a/orbit-compose/src/main/kotlin/org/orbitmvi/orbit/compose/ContainerHostExtensions.kt
+++ b/orbit-compose/src/main/kotlin/org/orbitmvi/orbit/compose/ContainerHostExtensions.kt
@@ -103,10 +103,10 @@ public fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.co
  * Active subscriptions from this operator count towards [repeatOnSubscription] subscribers.
  */
 @Composable
-public fun <STATE : Any, SIDE_EFFECT : Any, UI_STATE : Any> ContainerHostWithExtState<
+public fun <STATE : Any, SIDE_EFFECT : Any, EXT_STATE : Any> ContainerHostWithExtState<
     STATE,
     SIDE_EFFECT,
-    UI_STATE,
-    >.collectExtState(lifecycleState: Lifecycle.State = androidx.lifecycle.Lifecycle.State.STARTED): State<UI_STATE> {
+    EXT_STATE,
+    >.collectExtState(lifecycleState: Lifecycle.State = androidx.lifecycle.Lifecycle.State.STARTED): State<EXT_STATE> {
     return container.extStateFlow.collectAsStateWithLifecycle(minActiveState = lifecycleState)
 }

--- a/orbit-compose/src/test/kotlin/org/orbitmvi/orbit/compose/ComposeExtStateTest.kt
+++ b/orbit-compose/src/test/kotlin/org/orbitmvi/orbit/compose/ComposeExtStateTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2024 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
-package org.orbitmvi.orbit.viewmodel
+package org.orbitmvi.orbit.compose
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.State
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.lifecycle.Lifecycle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -24,21 +29,30 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.ContainerHostWithExtState
 import org.orbitmvi.orbit.RealSettings
 import org.orbitmvi.orbit.internal.RealContainer
+import org.robolectric.RobolectricTestRunner
 import kotlin.random.Random
 import kotlin.test.assertEquals
 
-class ContainerHostExtensionsKtTest {
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+class ComposeExtStateTest {
 
     @get:Rule
     val rule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
     private val mockLifecycleOwner = MockLifecycleOwner()
 
@@ -56,23 +70,37 @@ class ContainerHostExtensionsKtTest {
         )
     }
 
+    private val containerHostWithExtState = object : ContainerHostWithExtState<Int, Int, ExtState> {
+        override val container = containerHost.container.withExtState { ExtState(it) }
+    }
+
     @Before
-    @ExperimentalCoroutinesApi
     fun beforeTest() {
         Dispatchers.setMain(Dispatchers.Unconfined)
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_STOP)
     }
 
     @After
-    @ExperimentalCoroutinesApi
     fun afterTest() {
         Dispatchers.resetMain()
         scope.cancel()
     }
 
+    private fun initialiseContainerHostWithExtState(block: @Composable ContainerHostWithExtState<Int, Int, ExtState>.() -> State<ExtState>) {
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalLifecycleOwner provides mockLifecycleOwner
+            ) {
+                val state = containerHostWithExtState.block()
+
+                println(state)
+            }
+        }
+    }
+
     @Test
-    fun state_subscribes_on_start() {
-        containerHost.observe(mockLifecycleOwner, state = { })
+    fun as_state_subscribes_on_start() {
+        initialiseContainerHostWithExtState { collectExtState() }
 
         // Ensure there are no subscribers
         assertEquals(0, testSubscribedCounter.counter)
@@ -83,8 +111,8 @@ class ContainerHostExtensionsKtTest {
     }
 
     @Test
-    fun state_unsubscribes_on_stop() {
-        containerHost.observe(mockLifecycleOwner, state = { })
+    fun as_state_unsubscribes_on_stop() {
+        initialiseContainerHostWithExtState { collectExtState() }
 
         // Start and ensure there is one subscriber
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
@@ -96,8 +124,8 @@ class ContainerHostExtensionsKtTest {
     }
 
     @Test
-    fun state_resubscribes_when_restarted() {
-        containerHost.observe(mockLifecycleOwner, state = { })
+    fun as_state_resubscribes_when_restarted() {
+        initialiseContainerHostWithExtState { collectExtState() }
 
         // Start and ensure there is one subscriber
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
@@ -113,8 +141,8 @@ class ContainerHostExtensionsKtTest {
     }
 
     @Test
-    fun state_subscribes_on_custom_lifecycle() {
-        containerHost.observe(mockLifecycleOwner, lifecycleState = Lifecycle.State.RESUMED, state = { })
+    fun as_state_subscribes_on_custom_lifecycle() {
+        initialiseContainerHostWithExtState { collectExtState(Lifecycle.State.RESUMED) }
 
         // Ensure there are no subscribers
         assertEquals(0, testSubscribedCounter.counter)
@@ -125,8 +153,8 @@ class ContainerHostExtensionsKtTest {
     }
 
     @Test
-    fun state_unsubscribes_on_stop_with_custom_lifecycle() {
-        containerHost.observe(mockLifecycleOwner, lifecycleState = Lifecycle.State.RESUMED, state = { })
+    fun as_state_unsubscribes_on_stop_with_custom_lifecycle() {
+        initialiseContainerHostWithExtState { collectExtState(Lifecycle.State.RESUMED) }
 
         // Start and ensure there is one subscriber
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_RESUME)
@@ -138,10 +166,11 @@ class ContainerHostExtensionsKtTest {
     }
 
     @Test
-    fun state_resubscribes_when_restarted_on_custom_lifecycle() {
-        containerHost.observe(mockLifecycleOwner, lifecycleState = Lifecycle.State.RESUMED, state = { })
+    fun as_state_resubscribes_when_restarted_on_custom_lifecycle() = runTest {
+        initialiseContainerHostWithExtState { collectExtState(Lifecycle.State.RESUMED) }
 
         // Start and ensure there is one subscriber
+
         mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_RESUME)
         assertEquals(1, testSubscribedCounter.counter)
 
@@ -154,87 +183,6 @@ class ContainerHostExtensionsKtTest {
         assertEquals(1, testSubscribedCounter.counter)
     }
 
-    @Test
-    fun side_effect_subscribes_on_start() {
-        containerHost.observe(mockLifecycleOwner, sideEffect = { })
-
-        // Ensure there are no subscribers
-        assertEquals(0, testSubscribedCounter.counter)
-
-        // Start and ensure there is one subscriber
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
-        assertEquals(1, testSubscribedCounter.counter)
-    }
-
-    @Test
-    fun side_effect_unsubscribes_on_stop() {
-        containerHost.observe(mockLifecycleOwner, sideEffect = { })
-
-        // Start and ensure there is one subscriber
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
-        assertEquals(1, testSubscribedCounter.counter)
-
-        // Stop and ensure there are no subscribers
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_STOP)
-        assertEquals(0, testSubscribedCounter.counter)
-    }
-
-    @Test
-    fun side_effect_resubscribes_when_restarted() {
-        containerHost.observe(mockLifecycleOwner, sideEffect = { })
-
-        // Start and ensure there is one subscriber
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
-        assertEquals(1, testSubscribedCounter.counter)
-
-        // Stop and ensure there are no subscribers
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_STOP)
-        assertEquals(0, testSubscribedCounter.counter)
-
-        // Re-start and ensure there is one subscriber
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_START)
-        assertEquals(1, testSubscribedCounter.counter)
-    }
-
-    @Test
-    fun side_effect_subscribes_on_custom_lifecycle() {
-        containerHost.observe(mockLifecycleOwner, lifecycleState = Lifecycle.State.RESUMED, sideEffect = { })
-
-        // Ensure there are no subscribers
-        assertEquals(0, testSubscribedCounter.counter)
-
-        // Start and ensure there is one subscriber
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_RESUME)
-        assertEquals(1, testSubscribedCounter.counter)
-    }
-
-    @Test
-    fun side_effect_unsubscribes_on_stop_with_custom_lifecycle() {
-        containerHost.observe(mockLifecycleOwner, lifecycleState = Lifecycle.State.RESUMED, sideEffect = { })
-
-        // Start and ensure there is one subscriber
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_RESUME)
-        assertEquals(1, testSubscribedCounter.counter)
-
-        // Stop and ensure there are no subscribers
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_STOP)
-        assertEquals(0, testSubscribedCounter.counter)
-    }
-
-    @Test
-    fun side_effect_resubscribes_when_restarted_on_custom_lifecycle() {
-        containerHost.observe(mockLifecycleOwner, lifecycleState = Lifecycle.State.RESUMED, sideEffect = { })
-
-        // Start and ensure there is one subscriber
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_RESUME)
-        assertEquals(1, testSubscribedCounter.counter)
-
-        // Stop and ensure there are no subscribers
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_STOP)
-        assertEquals(0, testSubscribedCounter.counter)
-
-        // Re-start and ensure there is one subscriber
-        mockLifecycleOwner.dispatchEvent(Lifecycle.Event.ON_RESUME)
-        assertEquals(1, testSubscribedCounter.counter)
-    }
+    @JvmInline
+    value class ExtState(val value: Int)
 }

--- a/orbit-compose/src/test/kotlin/org/orbitmvi/orbit/compose/ComposeExtensionsTest.kt
+++ b/orbit-compose/src/test/kotlin/org/orbitmvi/orbit/compose/ComposeExtensionsTest.kt
@@ -44,7 +44,7 @@ import kotlin.test.assertEquals
 @Suppress("DEPRECATION")
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
-class ContainerHostExtensionsKtTest {
+class ComposeExtensionsTest {
 
     @get:Rule
     val rule = InstantTaskExecutorRule()
@@ -61,9 +61,10 @@ class ContainerHostExtensionsKtTest {
     private val containerHost = object : ContainerHost<Int, Int> {
         override val container = RealContainer<Int, Int>(
             initialState = Random.nextInt(),
-            parentScope = scope,
-            settings = RealSettings(),
-            subscribedCounterOverride = testSubscribedCounter
+            settings = RealSettings(
+                subscribedCounter = testSubscribedCounter,
+                parentScope = scope,
+            ),
         )
     }
 
@@ -84,7 +85,7 @@ class ContainerHostExtensionsKtTest {
             CompositionLocalProvider(
                 LocalLifecycleOwner provides mockLifecycleOwner
             ) {
-                block(containerHost)
+                containerHost.block()
             }
         }
     }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHostWithExtState.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHostWithExtState.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit
+
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import org.orbitmvi.orbit.internal.repeatonsubscription.refCount
+
+public class ContainerWithExtState<State : Any, SideEffect : Any, UiState : Any>(
+    override val actual: Container<State, SideEffect>,
+    mapper: (State) -> UiState,
+) : ContainerDecorator<State, SideEffect> {
+
+    public val extStateFlow: StateFlow<UiState> = stateFlow.map(mapper)
+        .stateIn(scope, started = SharingStarted.WhileSubscribed(), initialValue = mapper(actual.stateFlow.value))
+        .refCount(actual.settings.subscribedCounter)
+}
+
+public interface ContainerHostWithExtState<State : Any, SideEffect : Any, ExtState : Any> :
+    ContainerHost<State, SideEffect> {
+    override val container: ContainerWithExtState<State, SideEffect, ExtState>
+
+    public fun Container<State, SideEffect>.withExtState(
+        mapper: (State) -> ExtState,
+    ): ContainerWithExtState<State, SideEffect, ExtState> = ContainerWithExtState(this, mapper)
+}

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/CoroutineScopeExtensions.kt
@@ -42,8 +42,7 @@ public fun <STATE : Any, SIDE_EFFECT : Any> CoroutineScope.container(
 ): Container<STATE, SIDE_EFFECT> {
     val realContainer = RealContainer<STATE, SIDE_EFFECT>(
         initialState = initialState,
-        settings = SettingsBuilder().apply { buildSettings() }.settings,
-        parentScope = this
+        settings = SettingsBuilder().apply { buildSettings() }.apply(RealSettings(parentScope = this))
     )
     return if (onCreate == null) {
         TestContainerDecorator(

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
@@ -25,7 +25,6 @@ import org.orbitmvi.orbit.idling.IdlingResource
 import org.orbitmvi.orbit.idling.NoopIdlingResource
 import org.orbitmvi.orbit.internal.repeatonsubscription.DelayingSubscribedCounter
 import org.orbitmvi.orbit.internal.repeatonsubscription.SubscribedCounter
-import kotlin.time.Duration.Companion.milliseconds
 
 public data class RealSettings(
     public val sideEffectBufferSize: Int = Channel.BUFFERED,

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/TestContainerDecorator.kt
@@ -17,7 +17,6 @@
 package org.orbitmvi.orbit.internal
 
 import kotlinx.atomicfu.atomic
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -55,14 +54,13 @@ public class TestContainerDecorator<STATE : Any, SIDE_EFFECT : Any>(
 
     public fun test(
         initialState: STATE? = null,
-        settings: RealSettings,
-        testScope: CoroutineScope
+        settings: RealSettings
     ) {
         val testDelegate = RealContainer<STATE, SIDE_EFFECT>(
             initialState = initialState ?: originalInitialState,
-            parentScope = testScope,
-            settings = settings,
-            subscribedCounterOverride = AlwaysSubscribedCounter
+            settings = settings.copy(
+                subscribedCounter = AlwaysSubscribedCounter
+            ),
         )
 
         val testDelegateSet = delegate.compareAndSet(

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ExtStateTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ExtStateTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * File modified by Mikołaj Leszczyński & Appmattus Limited
+ * See: https://github.com/orbit-mvi/orbit-mvi/compare/c5b8b3f2b83b5972ba2ad98f73f75086a89653d3...main
+ */
+
+package org.orbitmvi.orbit.internal
+
+import app.cash.turbine.test
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.orbitmvi.orbit.ContainerHostWithExtState
+import org.orbitmvi.orbit.container
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ExtStateTest {
+
+    @Test
+    fun initial_state_is_emitted_on_connection() = runTest {
+        val initialState = TestInternalState()
+        val middleware = Middleware(this, initialState)
+        middleware.container.extStateFlow.test {
+            assertEquals(initialState.toExternal(), awaitItem())
+        }
+    }
+
+    @Test
+    fun latest_state_is_emitted_on_connection() = runTest {
+        val initialState = TestInternalState()
+        val middleware = Middleware(this, initialState)
+        val action = Random.nextInt()
+        middleware.container.extStateFlow.test {
+            middleware.something(action)
+            assertEquals(initialState.toExternal(), awaitItem())
+            assertEquals(TestInternalState(action).toExternal(), awaitItem())
+        }
+
+        middleware.container.extStateFlow.test {
+            assertEquals(TestInternalState(action).toExternal(), awaitItem())
+        }
+    }
+
+    @Test
+    fun current_state_is_set_to_the_initial_state_after_instantiation() = runTest {
+        val initialState = TestInternalState()
+        val middleware = Middleware(this, initialState)
+
+        assertEquals(initialState.toExternal(), middleware.container.extStateFlow.value)
+    }
+
+    @Test
+    fun current_state_is_up_to_date_after_modification() = runTest {
+        val initialState = TestInternalState()
+        val middleware = Middleware(this, initialState)
+        val action = Random.nextInt()
+        middleware.container.extStateFlow.test {
+            skipItems(1)
+            middleware.something(action).join()
+
+            val newState = awaitItem()
+
+            assertEquals(middleware.container.extStateFlow.value, newState)
+        }
+    }
+
+    private data class TestInternalState(val id: Int = Random.nextInt())
+    private data class TestExternalState(val id: Int)
+
+    private fun TestInternalState.toExternal() = TestExternalState(id)
+
+    private inner class Middleware(scope: TestScope, initialState: TestInternalState) :
+        ContainerHostWithExtState<TestInternalState, String, TestExternalState> {
+        override val container = scope.backgroundScope.container<TestInternalState, String>(initialState)
+            .withExtState { it.toExternal() }
+
+        fun something(action: Int) = intent {
+            reduce {
+                state.copy(id = action)
+            }
+        }
+    }
+}

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslRepeatOnSubscriptionTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslRepeatOnSubscriptionTest.kt
@@ -45,7 +45,9 @@ internal class SimpleDslRepeatOnSubscriptionTest {
 
     private val simpleSyntax = SimpleSyntax(
         containerContext = ContainerContext<Unit, Unit>(
-            settings = RealSettings(),
+            settings = RealSettings(
+                parentScope = testScope
+            ),
             postSideEffect = {},
             reduce = {},
             subscribedCounter = testSubscribedCounter,

--- a/samples/orbit-calculator/src/main/kotlin/org/orbitmvi/orbit/sample/calculator/CalculatorState.kt
+++ b/samples/orbit-calculator/src/main/kotlin/org/orbitmvi/orbit/sample/calculator/CalculatorState.kt
@@ -20,6 +20,6 @@
 
 package org.orbitmvi.orbit.sample.calculator
 
-interface CalculatorState {
+data class CalculatorState(
     val digitalDisplay: String
-}
+)

--- a/website/docs/Compose/overview.md
+++ b/website/docs/Compose/overview.md
@@ -39,3 +39,20 @@ fun SomeScreen(viewModel: SomeViewModel) {
 }
 ```
 
+## Subscribing to a ContainerHost with external state in Compose
+
+If you're using a [ContainerHostWithExtState](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host-with-ext-state/),
+you can use the `collectExtState` extension function to collect the state in the
+UI.
+
+``` kotlin
+@Composable
+fun SomeScreen(viewModel: SomeViewModel) {
+  val state by viewModel.collectExtState()
+  
+  SomeContent(
+    state = state
+  )
+}
+```
+

--- a/website/docs/Core/overview.md
+++ b/website/docs/Core/overview.md
@@ -106,6 +106,45 @@ class ExampleViewModel(
 }
 ```
 
+### ContainerHostWithExtState
+
+A
+[ContainerHostWithExtState](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host-with-ext-state/)
+is used whenever you want to have separation between the internal and external
+states of a ContainerHost.
+
+Let's define an outside consumer as anything that consumes the state of the
+ContainerHost and is external to it - e.g. a UI.
+
+Internal state is the raw ContainerHost's state that is not well suited to
+consumption outside of the ContainerHost. It may contain lots of unnecessary
+information and you may see the complexity bleeding into the UI. Ideally UIs
+should not contain any business logic
+
+External state is the state that is exposed to the outside world. It is a mapped
+representation of the internal state that contains the minimum necessary data
+for outside consumers. The data is mapped in a way that is ready for consumption
+, avoiding the need for any additional processing in the UI.
+
+Creating such a separation is easy:
+
+``` kotlin
+class ExampleViewModel(
+    savedStateHandle: SavedStateHandle
+) : ViewModel(), ContainerHostWithExtState<ExampleState, ExampleSideEffect, ExampleExtState> {
+    // create a container
+    val container = container<ExampleState, ExampleSideEffect>(ExampleState(), savedStateHandle)
+        .withExtState(::mapExternalState)
+
+    …
+    
+    private fun mapExternalState(state: ExampleState): ExampleExtState {
+        // Process the internal state into something the UI can easily consume...
+        return ExampleExtState(...)
+    }
+}
+```
+
 ## Core operators
 
 The Core module contains built-in Orbit operators. Here's how


### PR DESCRIPTION
A pattern that we often see is that as a `ContainerHost` grows in complexity, a lot of the Container's state may exist only to track the `ContainerHost`'s state.

Essentially as we're mixing internal and external (e.g. UI) state it becomes increasingly taxing to hoist the UI state out of the container's state.

This PR introduces an optional `ContainerHostWithExtState` and `ContainerWithExtState` that introduce a simple mapping layer and expose `extStateFlow` for collection in the UI. We take the internal state and apply the mapper in order to turn it into an external state. All you need to do as the dev is to implement this mapper.