### PR TITLE
Replace AtomicFu with Kotlin standard library implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ buildscript {
         classpath(libs.buildscript.android)
         classpath(libs.buildscript.kotlin)
         classpath(libs.buildscript.safeargs)
-        classpath(libs.buildscript.atomicfu)
         classpath(libs.buildscript.hilt)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,18 +16,18 @@
 
 [versions]
 
-kotlin = "2.1.10"
+kotlin = "2.1.20"
 coroutines = "1.10.1"
 
 # Plugins
 gradleVersionsPlugin = "0.52.0"
-gradleAndroidPlugin = "8.9.0"
+gradleAndroidPlugin = "8.9.1"
 gradleMavenPublishPlugin = "0.31.0"
 markdownLintPlugin = "0.6.0"
 detektPlugin = "1.23.8"
 dokka = "2.0.0"
-compose-multiplatform = "1.7.0"
-hilt = "2.55"
+compose-multiplatform = "1.7.3"
+hilt = "2.56"
 
 # Androidx
 androidxActivityCompose = "1.10.1"
@@ -36,7 +36,7 @@ androidxCompose = "1.7.8"
 androidxConstraintlayout = "2.2.1"
 androidxHilt = "1.2.0"
 androidxLifecycle = "2.8.7"
-androidxLifecycleMultiplatform = "2.9.0-alpha04"
+androidxLifecycleMultiplatform = "2.9.0-alpha05"
 androidxNavigation = "2.8.9"
 
 # Google

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ gradleAndroidPlugin = "8.9.0"
 gradleMavenPublishPlugin = "0.31.0"
 markdownLintPlugin = "0.6.0"
 detektPlugin = "1.23.8"
-atomicfu = "0.27.0"
 dokka = "2.0.0"
 compose-multiplatform = "1.7.0"
 hilt = "2.55"
@@ -139,7 +138,6 @@ buildscript_android = { module = "com.android.tools.build:gradle", version.ref =
 buildscript_kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 buildscript_detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektPlugin" }
 buildscript_safeargs = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "androidxNavigation" }
-buildscript_atomicfu = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version.ref = "atomicfu" }
 buildscript_hilt = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 
 [plugins]
@@ -149,6 +147,5 @@ gradleMavenPublishPlugin = { id = "com.vanniktech.maven.publish", version.ref = 
 gradleVersionsPlugin = { id = "com.github.ben-manes.versions", version.ref = "gradleVersionsPlugin" }
 markdownlintGradlePlugin = { id = "com.appmattus.markdown", version.ref = "markdownLintPlugin" }
 kotlin-pluginSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }

--- a/orbit-core/orbit-core_build.gradle.kts
+++ b/orbit-core/orbit-core_build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     kotlin("multiplatform")
     id(libs.plugins.gradleMavenPublishPlugin.get().pluginId)
     id(libs.plugins.dokkaPlugin.get().pluginId)
-    id(libs.plugins.atomicfu.get().pluginId)
 }
 
 kotlin {
@@ -64,6 +63,7 @@ kotlin {
         all {
             languageSettings.optIn("kotlin.RequiresOptIn")
             languageSettings.optIn("org.orbitmvi.orbit.annotation.OrbitInternal")
+            languageSettings.optIn("kotlin.concurrent.atomics.ExperimentalAtomicApi")
         }
 
         commonMain.dependencies {

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -112,8 +112,8 @@ public class RealContainer<STATE : Any, SIDE_EFFECT : Any>(
                 for ((job, intent) in dispatchChannel) {
                     val exceptionHandlerContext =
                         CoroutineName("$COROUTINE_NAME_INTENT${intentCounter.fetchAndIncrement()}") +
-                                job +
-                                settings.intentLaunchingDispatcher
+                            job +
+                            settings.intentLaunchingDispatcher
                     launch(exceptionHandlerContext) {
                         runCatching { pluginContext.intent() }.onFailure { e ->
                             settings.exceptionHandler?.handleException(

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslIdlingTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslIdlingTest.kt
@@ -20,10 +20,8 @@
 
 package org.orbitmvi.orbit.syntax.simple
 
-import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -35,11 +33,13 @@ import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.container
 import org.orbitmvi.orbit.idling.IdlingResource
 import org.orbitmvi.orbit.test.assertEventually
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class SimpleDslIdlingTest {
 
     private val testIdlingResource = TestIdlingResource()
@@ -123,19 +123,19 @@ internal class SimpleDslIdlingTest {
     data class TestState(val value: Int)
 
     class TestIdlingResource : IdlingResource {
-        private val counter = atomic(0)
+        private val counter = AtomicInt(0)
 
         override fun increment() {
-            counter.incrementAndGet()
+            counter.incrementAndFetch()
         }
 
         override fun decrement() {
-            counter.decrementAndGet()
+            counter.decrementAndFetch()
         }
 
         override fun close() = Unit
 
-        fun isIdle() = counter.value == 0
+        fun isIdle() = counter.load() == 0
     }
 
     companion object {

--- a/orbit-test/orbit-test_build.gradle.kts
+++ b/orbit-test/orbit-test_build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     kotlin("multiplatform")
     id(libs.plugins.gradleMavenPublishPlugin.get().pluginId)
     id(libs.plugins.dokkaPlugin.get().pluginId)
-    id(libs.plugins.atomicfu.get().pluginId)
 }
 
 kotlin {
@@ -61,6 +60,10 @@ kotlin {
     applyDefaultHierarchyTemplate()
 
     sourceSets {
+        all {
+            languageSettings.optIn("kotlin.concurrent.atomics.ExperimentalAtomicApi")
+        }
+
         commonMain.dependencies {
             implementation(kotlin("test-common"))
             api(libs.kotlinCoroutines)

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InitTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/InitTest.kt
@@ -16,12 +16,12 @@
 
 package org.orbitmvi.orbit.test
 
-import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.container
+import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -36,7 +36,7 @@ internal class InitTest {
             expectInitialState()
         }
 
-        assertEquals(false, mockDependency.createCalled.value)
+        assertEquals(false, mockDependency.createCalled.load())
     }
 
     @Test
@@ -47,7 +47,7 @@ internal class InitTest {
             runOnCreate()
         }
 
-        assertEquals(true, mockDependency.createCalled.value)
+        assertEquals(true, mockDependency.createCalled.load())
     }
 
     @Test
@@ -80,10 +80,10 @@ internal class InitTest {
     }
 
     private class FakeDependency : BogusDependency {
-        val createCalled = atomic(false)
+        val createCalled = AtomicBoolean(false)
 
         override fun create() {
-            createCalled.compareAndSet(expect = false, update = true)
+            createCalled.compareAndSet(expectedValue = false, newValue = true)
         }
     }
 }

--- a/test-common/test-common_build.gradle.kts
+++ b/test-common/test-common_build.gradle.kts
@@ -20,7 +20,6 @@
 
 plugins {
     kotlin("multiplatform")
-    id(libs.plugins.atomicfu.get().pluginId)
 }
 
 kotlin {
@@ -59,6 +58,10 @@ kotlin {
     applyDefaultHierarchyTemplate()
 
     sourceSets {
+        all {
+            languageSettings.optIn("kotlin.concurrent.atomics.ExperimentalAtomicApi")
+        }
+
         commonMain.dependencies {
             implementation(libs.kotlinCoroutines)
             implementation(kotlin("stdlib"))


### PR DESCRIPTION
Kotlin 2.1.20 introduces common atomic types to the standard library - see https://kotlinlang.org/docs/whatsnew2120.html#common-atomic-types. By switching to this we are able to remove the dependency on AtomicFu which often causes us dependency issues.

Fixes #248 