### PR TITLE
Enable jacoco coverage for multiplatform

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -72,11 +72,8 @@ jobs:
             -   name: Unit tests
                 run: ./gradlew check -xlint
 
-            -   name: Upload jacoco
-                uses: actions/upload-artifact@v4
-                with:
-                    name: jacoco
-                    path: '**/jacocoTestReport.xml'
+            -   name: Re-generate jacoco reports
+                run: ./gradlew jacocoTestReport
 
             -   name: Upload test artifacts
                 if: failure()

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -72,6 +72,12 @@ jobs:
             -   name: Unit tests
                 run: ./gradlew check -xlint
 
+            -   name: Upload jacoco
+                uses: actions/upload-artifact@v4
+                with:
+                    name: jacoco
+                    path: '**/jacocoTestReport.xml'
+
             -   name: Upload test artifacts
                 if: failure()
                 uses: actions/upload-artifact@v4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ retrofit = "2.11.0"
 # Testing
 androidxCoreTesting = "2.2.0"
 androidxEspresso = "3.6.1"
-jacoco = "0.8.12"
+jacoco = "0.8.13"
 junit4 = "4.13.2"
 junitJupiterEngine = "5.12.2"
 junitPlatformConsole = "1.12.2"

--- a/gradle/scripts/jacoco-android.gradle.kts
+++ b/gradle/scripts/jacoco-android.gradle.kts
@@ -59,5 +59,5 @@ tasks.withType<Test> {
 }
 
 configure<JacocoPluginExtension> {
-    toolVersion = "0.8.12"
+    toolVersion = "0.8.13"
 }

--- a/gradle/scripts/jacoco.gradle.kts
+++ b/gradle/scripts/jacoco.gradle.kts
@@ -28,18 +28,12 @@ val jacocoTask = tasks.register("jacocoTestReport", JacocoReport::class) {
         "src/jvmMain"
     )
 
-    // Include all compiled classes.
     val classFiles = layout.buildDirectory.dir("classes/kotlin/jvm").get().asFile.walkBottomUp().toSet()
 
-    // This helps with test coverage accuracy.
     classDirectories.setFrom(classFiles)
     sourceDirectories.setFrom(files(coverageSourceDirs))
 
-    // The resulting test report in binary format.
-    // It serves as the basis for human-readable reports.
-    layout.buildDirectory.files("jacoco/jvmTest.exec").let {
-        executionData.setFrom(it)
-    }
+    executionData.setFrom(layout.buildDirectory.files("jacoco/jvmTest.exec"))
 
     reports {
         html.required.set(true)

--- a/gradle/scripts/jacoco.gradle.kts
+++ b/gradle/scripts/jacoco.gradle.kts
@@ -20,7 +20,27 @@
 
 apply<JacocoPlugin>()
 
-val jacocoTask = tasks.withType<JacocoReport> {
+val jacocoTask = tasks.register("jacocoTestReport", JacocoReport::class) {
+    dependsOn(tasks.withType(Test::class))
+
+    val coverageSourceDirs = arrayOf(
+        "src/commonMain",
+        "src/jvmMain"
+    )
+
+    // Include all compiled classes.
+    val classFiles = layout.buildDirectory.dir("classes/kotlin/jvm").get().asFile.walkBottomUp().toSet()
+
+    // This helps with test coverage accuracy.
+    classDirectories.setFrom(classFiles)
+    sourceDirectories.setFrom(files(coverageSourceDirs))
+
+    // The resulting test report in binary format.
+    // It serves as the basis for human-readable reports.
+    layout.buildDirectory.files("jacoco/jvmTest.exec").let {
+        executionData.setFrom(it)
+    }
+
     reports {
         html.required.set(true)
         xml.required.set(true)
@@ -33,5 +53,5 @@ tasks.withType<Test> {
 }
 
 configure<JacocoPluginExtension> {
-    toolVersion = "0.8.12"
+    toolVersion = "0.8.13"
 }


### PR DESCRIPTION
Multiplatform code doesn't automatically add a `jacocoTestReport` task so we have to manually add one and tell it about our source files.

Hopefully fixing #285 