### PR TITLE
Update docs for unified OrbitContainerHost API

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,19 @@ sealed class CalculatorSideEffect {
 ### Create the ViewModel
 
 1. Implement the
-   [ContainerHost](orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHost.kt)
+   [OrbitContainerHost](orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHost.kt)
    interface
-1. Override the `container` field and use the `ViewModel.container` factory
+1. Override the `container` field and use the `ViewModel.orbitContainer` factory
    function to build an Orbit
-   [Container](orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt)
+   [OrbitContainer](orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt)
    in your
-   [ContainerHost](orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHost.kt)
+   [OrbitContainerHost](orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHost.kt)
 
 ```kotlin
-class CalculatorViewModel: ContainerHost<CalculatorState, CalculatorSideEffect>, ViewModel() {
+class CalculatorViewModel: OrbitContainerHost<CalculatorState, CalculatorState, CalculatorSideEffect>, ViewModel() {
 
     // Include `orbit-viewmodel` for the factory function
-    override val container = container<CalculatorState, CalculatorSideEffect>(CalculatorState())
+    override val container = orbitContainer<CalculatorState, CalculatorSideEffect>(CalculatorState())
 
     fun add(number: Int) = intent {
         postSideEffect(CalculatorSideEffect.Toast("Adding $number to ${state.total}!"))

--- a/samples/orbit-calculator/README.md
+++ b/samples/orbit-calculator/README.md
@@ -13,7 +13,7 @@ This sample implements a simple calculator using [Orbit Multiplatform](https://g
 
 - [CalculatorViewModel](src/main/kotlin/org/orbitmvi/orbit/sample/calculator/CalculatorViewModel.kt)
   uses a `SavedStateHandle` for retaining the current state. It implements a
-  private [ContainerHost](../../orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHost.kt)
+  private [OrbitContainerHost](../../orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHost.kt)
   so the internal implementation of [CalculatorState](src/main/kotlin/org/orbitmvi/orbit/sample/calculator/CalculatorState.kt)
   is not exposed.
 

--- a/website/docs/Compose/index.md
+++ b/website/docs/Compose/index.md
@@ -7,7 +7,7 @@ import latestRelease from "@site/src/plugins/github-latest-release/generated/dat
 
 # Jetpack Compose and Compose Multiplatform
 
-The module provides [ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+The module provides [OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
 extensions for easy subscription from `Composables`.
 
 :::caution
@@ -20,9 +20,9 @@ Compose Multiplatform support added in Orbit v10.0.0.
 
 <CodeBlock language="kotlin">implementation("org.orbit-mvi:orbit-compose:{latestRelease.tag_name}")</CodeBlock>
 
-## Subscribing to a ContainerHost in Compose
+## Subscribing to an OrbitContainerHost in Compose
 
-Use the method below to subscribe to a [ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+Use the method below to subscribe to an [OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
 in Compose.
 
 The functions safely follow the Composable lifecycle and will automatically
@@ -60,8 +60,8 @@ Alternatively, `TextField` can be provided a `TextFieldState` which we can
 provide and observe in our `ViewModel`:
 
 ```kotlin
-class TextViewModel : ViewModel(), ContainerHost<TextViewModel.State, Nothing> {
-    override val container: Container<State, Nothing> = container(State()) {
+class TextViewModel : ViewModel(), OrbitContainerHost<TextViewModel.State, TextViewModel.State, Nothing> {
+    override val container: OrbitContainer<State, State, Nothing> = orbitContainer(State()) {
         coroutineScope {
             launch {
                 snapshotFlow { state.textFieldState.text }.collectLatest { text ->

--- a/website/docs/Core/architecture.md
+++ b/website/docs/Core/architecture.md
@@ -25,8 +25,8 @@ by itself. It should know only how to render itself based on the input state.
 
 ```mermaid
 graph LR
-	A[UI] -->|calls| B(ContainerHost)
-	B --> C(Container)
+	A[UI] -->|calls| B(OrbitContainerHost)
+	B --> C(OrbitContainer)
 	C --> D(Transformer)
 	D -->|events| E(Reducer)
 	E -->|state updates| A
@@ -35,12 +35,12 @@ graph LR
 We can map the above logic onto real components.
 
 1. UI invokes functions on a class implementing the
-   [ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+   [OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
    interface. Typically in Android this might be an Activity, Fragment
    or a simple View. However, an Orbit system can also be run without
    any UI, for example as a background service.
 1. The functions call through to a
-   [Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+   [OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
    instance through the `intent` block which offloads work to a background
    coroutine and provides a DSL for side effects and reductions.
 1. Transformations are performed through user-defined business logic within
@@ -58,13 +58,13 @@ Notes:
 In the real world such a system cannot exist without side effects. Side effects
 are commonly truly one-off events like navigation, logging, analytics, toasts
 etc that do not alter the state of the Orbit
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/).
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/).
 As such there's a third Orbit operator that can deal with side effects.
 
 ```mermaid
 graph LR
-	A[UI] -->|calls| B(ContainerHost)
-	B --> C(Container)
+	A[UI] -->|calls| B(OrbitContainerHost)
+	B --> C(OrbitContainer)
 	C --> D(Transformer)
 	C --> D2(Side Effect)
 	D2 -->|side effects| A

--- a/website/docs/Core/index.md
+++ b/website/docs/Core/index.md
@@ -20,14 +20,14 @@ MVI and how its concepts map onto Orbit's components.
 ## Orbit container
 
 A
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
 is the heart of the Orbit MVI system. It retains the state, allows you to listen
 to side effects and state updates and allows you to modify the state through the
 `orbit` function which executes Orbit operators of your desired business logic.
 
 ### Subscribing to the container
 
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
 exposes flows that emit updates to the container state and side effects.
 
 - State emissions are conflated
@@ -42,10 +42,10 @@ sealed class ExampleSideEffect {
     data class Toast(val text: String)
 }
 
-class ExampleContainerHost(scope: CoroutineScope) : ContainerHost<ExampleState, ExampleSideEffect> {
-    
+class ExampleContainerHost(scope: CoroutineScope) : OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
+
     // create a container
-    override val container = scope.container<ExampleState, ExampleSideEffect>(ExampleState())
+    override val container = scope.orbitContainer<ExampleState, ExampleSideEffect>(ExampleState())
 
     fun doSomethingUseful() = intent {
         ...
@@ -58,7 +58,7 @@ private val viewModel = ExampleContainerHost(scope)
 fun main() {
 
     // subscribe to updates
-    // On Android, use ContainerHost.observe() from the orbit-viewmodel module
+    // On Android, use OrbitContainerHost.observe() from the orbit-viewmodel module
     scope.launch {
         viewModel.container.stateFlow.collect {
             // do something with the state
@@ -76,65 +76,69 @@ fun main() {
 }
 ```
 
-### ContainerHost
+### OrbitContainerHost
 
 A
-[ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+[OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
 is not strictly required to work with an Orbit
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/).
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/).
 However, Orbit's syntax is defined as an extension on this class. Additionally
 it simplifies and organises your business logic and so is highly recommended. A
-[ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+[OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
 typically defines MVI flows (your business logic and Orbit operators to be
 invoked on the
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/))
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/))
 as functions that can be called by e.g. the UI.
 
 In a typical implementation you would subclass Android's `ViewModel` and
 implement
-[ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+[OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
 in order to create an Orbit-enabled Android `ViewModel`.
 
 ```kotlin
 class ExampleViewModel(
     savedStateHandle: SavedStateHandle
-) : ViewModel(), ContainerHost<ExampleState, ExampleSideEffect> {
+) : ViewModel(), OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
     // create a container
-    val container = container<ExampleState, ExampleSideEffect>(ExampleState(), savedStateHandle)
+    val container = orbitContainer<ExampleState, ExampleSideEffect>(ExampleState(), savedStateHandle)
 
     …
 }
 ```
 
-### ContainerHostWithExternalState
+### External state
 
-A
-[ContainerHostWithExternalState](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host-with-external-state/)
-is used whenever you want to have separation between the internal and external
-states of a ContainerHost.
+`OrbitContainerHost` supports separation between internal and external states
+via its third type parameter. This is useful whenever the raw internal state is
+not well suited to consumption outside of the host (e.g. by a UI).
 
 Let's define an outside consumer as anything that consumes the state of the
-ContainerHost and is external to it - e.g. a UI.
+`OrbitContainerHost` and is external to it - e.g. a UI.
 
-Internal state is the raw ContainerHost's state that is not well suited to
-consumption outside of the ContainerHost. It may contain lots of unnecessary
+Internal state is the raw host's state that is not well suited to
+consumption outside of the host. It may contain lots of unnecessary
 information and you may see the complexity bleeding into the UI. Ideally UIs
 should not contain any business logic.
 
 External state is the state that is exposed to the outside world. It is a mapped
 representation of the internal state that contains the minimum necessary data
-for outside consumers. The data is mapped in a way that is ready for 
+for outside consumers. The data is mapped in a way that is ready for
 consumption, avoiding the need for any additional processing in the UI.
 
-Creating such a separation is easy:
+To use external state, specify a different type for the external state parameter
+of `OrbitContainerHost` and pass a `transformState` function to the container
+factory:
 
-``` kotlin
+```kotlin
 class ExampleViewModel(
     savedStateHandle: SavedStateHandle
-) : ViewModel(), ContainerHostWithExternalState<ExampleState, ExampleSideEffect, ExampleExtState> {
-    // create a container
-    val container = container<ExampleState, ExampleSideEffect>(ExampleState(), savedStateHandle)
-        .withExternalState(::transformState)
+) : ViewModel(), OrbitContainerHost<ExampleState, ExampleExtState, ExampleSideEffect> {
+    // create a container with external state transformation
+    override val container = orbitContainer<ExampleState, ExampleExtState, ExampleSideEffect>(
+        ExampleState(),
+        savedStateHandle,
+        ::transformState
+    )
 
     …
 
@@ -155,20 +159,20 @@ they map to MVI concepts:
 | block              | `intent { ... }`               | Contains business logic, allows you to invoke other operators within                                      |
 | transformation     | operations within `intent`     | Run business operations to transform data                                                                 |
 | posted side effect | `postSideEffect(...)`          | Sends one-off events to the side effect channel                                                           |
-| reduction          | `reduce { ... }`               | Atomically updates the Container's  state                                                                 |
+| reduction          | `reduce { ... }`               | Atomically updates the OrbitContainer's  state                                                                 |
 | -                  | `repeatOnSubscription { ... }` | Helps collect infinite flows only when there are active subscribers                                       |
 | -                  | `subIntent { ... }`            | Use this to break big `intent` blocks into smaller parts, or for parallel decomposition.                  |
 | -                  | `runOn { ... }`                | Useful for working with sealed class states. The block is only executed if (and while) the state matches. |
 
 Operators are invoked through the `intent` block in a
-[ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/).
+[OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/).
 For more information about which threads these operators run on please see
 [Threading](#threading).
 
 ### Transformation
 
 ```kotlin
-class Example : ContainerHost<ExampleState, ExampleSideEffect> {
+class Example : OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
     ...
 
     fun simpleExample() = intent {
@@ -197,7 +201,7 @@ of new intents until that code completes.
 ### Reduction
 
 ```kotlin
-class Example : ContainerHost<ExampleState, ExampleSideEffect> {
+class Example : OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
     ...
 
     fun simpleExample(number: Int) = intent {
@@ -212,7 +216,7 @@ Reducers take incoming events and the current state to produce a new state.
 ### Side effect
 
 ```kotlin
-class Example : ContainerHost<ExampleState, ExampleSideEffect> {
+class Example : OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
     ...
 
     fun simpleExample(number: Int) = intent {
@@ -230,7 +234,7 @@ This functionality is commonly used for things like truly one-off events,
 navigation, logging, analytics etc.
 
 You may post the side effect in order to send it to a
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)'s
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)'s
 side effect flow. Use this for view-related side effects like Toasts,
 Navigation, etc.
 
@@ -239,7 +243,7 @@ events such as navigation are delivered after re-subscription.
 
 :::caution
 
-`Container.sideEffectFlow` is designed for a single observer to ensure
+`OrbitContainer.sideEffectFlow` is designed for a single observer to ensure
 predictable side effect caching. If you need multiple observers, use `shareIn`,
 but note that caching may not apply to the resulting `SharedFlow`.
 
@@ -248,7 +252,7 @@ but note that caching may not apply to the resulting `SharedFlow`.
 ### Repeat on subscription
 
 ```kotlin
-class Example : ContainerHost<ExampleState, ExampleSideEffect> {
+class Example : OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
     ...
 
     fun simpleExample() = intent(idlingResource = false) {
@@ -280,10 +284,10 @@ is no longer the case.
 ### Sub-intent
 
 ```kotlin
-class Example : ContainerHost<ExampleState, ExampleSideEffect> {
+class Example : OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
     ...
     
-    override val container = scope.container<ExampleState, ExampleSideEffect>(
+    override val container = scope.orbitContainer<ExampleState, ExampleSideEffect>(
         ExampleState()
     ) {
         // Remember that this `onCreate` block is an implicit `intent`.
@@ -339,11 +343,11 @@ collecting several flows or performing several parallel operations on creation.
 ### RunOn
 
 ```kotlin
-class Example : ContainerHost<ExampleSealedClassState, ExampleSideEffect> {
+class Example : OrbitContainerHost<ExampleSealedClassState, ExampleSealedClassState, ExampleSideEffect> {
     ...
     
     override val container = 
-        scope.container<ExampleSealedClassState, ExampleSideEffect>(
+        scope.orbitContainer<ExampleSealedClassState, ExampleSideEffect>(
             ExampleSealedClassState.Loading
         )
 
@@ -375,12 +379,12 @@ get executed partially.
 
 Each simple syntax operator lambda has a receiver that exposes the current state
 of the
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
 as `state`
 
 ```kotlin
 perform("Toast the current state")
-class Example : ContainerHost<ExampleState, ExampleSideEffect> {
+class Example : OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
     ...
 
     fun anotherExample(number: Int) = intent {
@@ -399,12 +403,12 @@ not to change.
 
 :::
 
-## Container factories
+## OrbitContainer factories
 
 ```kotlin
 perform("Toast the current state")
-class Example : ContainerHost<ExampleState, ExampleSideEffect> {
-    override val container = container<ExampleState, ExampleSideEffect>(ExampleState()) {
+class Example : OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
+    override val container = orbitContainer<ExampleState, ExampleSideEffect>(ExampleState()) {
         // This block is an intent invoked when the container is first created
         reduce { ... }
     }
@@ -414,7 +418,7 @@ class Example : ContainerHost<ExampleState, ExampleSideEffect> {
 Containers are typically not created directly but through convenient factory
 functions. This allows you to pass through extra settings or an intent lambda to
 invoke when the
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
 is first created (important for containers that can be recreated from a saved
 state or live longer than the UI).
 
@@ -426,8 +430,8 @@ perform("Toast the current state")
 class Example(
     private val flow1: Flow<Int>,
     private val flow2: Flow<Int>,
-): ContainerHost<ExampleState, ExampleSideEffect> {
-    override val container = container<ExampleState, ExampleSideEffect>(ExampleState()) {
+): OrbitContainerHost<ExampleState, ExampleState, ExampleSideEffect> {
+    override val container = orbitContainer<ExampleState, ExampleSideEffect>(ExampleState()) {
         coroutineScope {
             repeatOnSubscription {
             launch {
@@ -445,7 +449,7 @@ class Example(
 ```
 
 Extra
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
 factory functionality is provided via extension functions. One example is
 `ViewModel` saved state support via a `SavedStateHandle`.
 
@@ -458,7 +462,7 @@ done by switching your coroutine context.
 
 ### Threading guarantees
 
-- Calls to Container.intent` do not block the caller. The
+- Calls to `OrbitContainer.intent` do not block the caller. The
   operations within are offloaded to an event-loop style background coroutine.
 - Generally it is good practice to make sure long-running operations are done
   in a switched coroutine context in order not to block the Orbit "event

--- a/website/docs/Core/index.md
+++ b/website/docs/Core/index.md
@@ -110,13 +110,13 @@ class ExampleViewModel(
 
 `OrbitContainerHost` supports separation between internal and external states
 via its third type parameter. This is useful whenever the raw internal state is
-not well suited to consumption outside of the host (e.g. by a UI).
+not well suited to consumption outside of the `OrbitContainerHost` (e.g. by a UI).
 
 Let's define an outside consumer as anything that consumes the state of the
 `OrbitContainerHost` and is external to it - e.g. a UI.
 
-Internal state is the raw host's state that is not well suited to
-consumption outside of the host. It may contain lots of unnecessary
+Internal state is the raw `OrbitContainerHost`'s state that is not well suited to
+consumption outside of the `OrbitContainerHost`. It may contain lots of unnecessary
 information and you may see the complexity bleeding into the UI. Ideally UIs
 should not contain any business logic.
 

--- a/website/docs/Test/index.md
+++ b/website/docs/Test/index.md
@@ -20,7 +20,7 @@ ensures predictable coroutine scoping and context through use of the
 ## Testing process
 
 1. Put the
-   [ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+   [OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
    in your chosen test mode using `test()`. You may optionally
    provide them with the initial state to seed the container with. This helps
    avoid having to call several intents just to get the container in the right
@@ -28,14 +28,14 @@ ensures predictable coroutine scoping and context through use of the
 2. (Optional) Run `runOnCreate()` within the test block to run the container
    create lambda.
 3. (Optional) Run `containerHost.foo()` to run the
-   [ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+   [OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
    intent of your choice.
 4. Await for side effects and states using `awaitSideEffect()`
    and `awaitState()`.
    `testContainerHost.assert { ... }`.
 
 Let's start and put our
-[ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+[OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
 into test mode. We pass in the test scope and initial state to seed the
 container with (you may omit it entirely to use the initial state from the real
 container).
@@ -65,8 +65,8 @@ fun exampleTest() = runTest {
 
 ### Run `onCreate`
 
-If the `Container` is created with `CoroutineScope.container()` or
-`ViewModel.container()` there is an option to provide the `onCreate` lambda.
+If the `OrbitContainer` is created with `CoroutineScope.orbitContainer()` or
+`ViewModel.orbitContainer()` there is an option to provide the `onCreate` lambda.
 In test mode this function must be run manually (if needed) by calling
 `runOnCreate`, so it's effectively isolated in the test; the other
 reason why is `onCreate` could include any number of `intent{}` calls, so it's
@@ -79,7 +79,7 @@ set a correct initial state instead.
 :::note
 
 `runOnCreate` can only be invoked once, before invoking any intents on
-`ContainerHost`.
+`OrbitContainerHost`.
 
 :::
 
@@ -290,11 +290,11 @@ fun exampleTest() = runTest {
 ## Testing intents that collect Flows
 
 We can run into situations where we subscribe
-our [ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+our [OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
 to an infinite (hot) flow of data like so:
 
 ```kotlin
-val container = scope.container<SomeState, Unit> {
+val container = scope.orbitContainer<SomeState, Unit> {
     intent {
         runOnSubscription {
             locationService.locationUpdates.collect {
@@ -351,8 +351,8 @@ to the test function.
 Consider the following example:
 
 ```kotlin
-class InfiniteFlowMiddleware : ContainerHost<List<Int>, Nothing> {
-    override val container: Container<List<Int>, Nothing> = someScope.container(listOf(42))
+class InfiniteFlowMiddleware : OrbitContainerHost<List<Int>, List<Int>, Nothing> {
+    override val container: OrbitContainer<List<Int>, List<Int>, Nothing> = someScope.orbitContainer(listOf(42))
 
     fun incrementForever() = intent {
         while (true) {

--- a/website/docs/ViewModel/index.md
+++ b/website/docs/ViewModel/index.md
@@ -7,18 +7,18 @@ import latestRelease from "@site/src/plugins/github-latest-release/generated/dat
 
 # Android and Common ViewModel
 
-The module provides [Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+The module provides [OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
 factory extensions on Android's [ViewModel](https://developer.android.com/topic/libraries/architecture/viewmodel) for:
 
 - Creating containers scoped with
   [ViewModelScope](https://developer.android.com/topic/libraries/architecture/coroutines#viewmodelscope)
   to automatically cancel the
-  [Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+  [OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
   whenever the `ViewModel` is cleared.
 - Saved state functionality via Jetpack's
   [Saved State module for ViewModel](https://developer.android.com/topic/libraries/architecture/viewmodel-savedstate)
   to automatically save and restore the
-  [Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+  [OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
   state on Activity or process death.
 
 :::caution
@@ -34,14 +34,14 @@ Common ViewModel (Multiplatform) support added in Orbit v10.0.0.
 ## Creating a container in a ViewModel
 
 This module contains a
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
 factory extension function on `ViewModel` to facilitate creating a scoped
 container.
 
 ```kotlin
-class ExampleViewModel : ContainerHost<ExampleState, Nothing>, ViewModel() {
+class ExampleViewModel : OrbitContainerHost<ExampleState, ExampleState, Nothing>, ViewModel() {
 
-    override val container = container<ExampleState, Nothing>(ExampleState())
+    override val container = orbitContainer<ExampleState, Nothing>(ExampleState())
 
     ...
 }
@@ -56,7 +56,7 @@ must be met:
 1. You must provide a 
    [SavedStateHandle](https://developer.android.com/reference/androidx/lifecycle/SavedStateHandle)
    to the
-   [Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+   [OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
    factory function, along with the
    [serializer](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md)
    for your state.
@@ -68,9 +68,9 @@ data class ExampleState(
 )
 
 // Pass the SavedStateHandle and serializer to your ViewModel
-class ExampleViewModel(savedStateHandle: SavedStateHandle) : ContainerHost<ExampleState, Nothing>, ViewModel() {
+class ExampleViewModel(savedStateHandle: SavedStateHandle) : OrbitContainerHost<ExampleState, ExampleState, Nothing>, ViewModel() {
 
-    override val container = container<ExampleState, Nothing>(
+    override val container = orbitContainer<ExampleState, Nothing>(
         initialState = ExampleState(),
         savedStateHandle = savedStateHandle,
         serializer = ExampleState.serializer()
@@ -93,7 +93,7 @@ conditions must be met:
 1. You must provide a
    [SavedStateHandle](https://developer.android.com/reference/androidx/lifecycle/SavedStateHandle)
    to the
-   [Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+   [OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
    factory function.
 
 ```kotlin
@@ -103,9 +103,9 @@ data class ExampleState(
 ) : Parcelable
 
 // Pass the SavedStateHandle to your ViewModel
-class ExampleViewModel(savedStateHandle: SavedStateHandle) : ContainerHost<ExampleState, Nothing>, ViewModel() {
+class ExampleViewModel(savedStateHandle: SavedStateHandle) : OrbitContainerHost<ExampleState, ExampleState, Nothing>, ViewModel() {
 
-    override val container = container<ExampleState, Nothing>(
+    override val container = orbitContainer<ExampleState, Nothing>(
         initialState = ExampleState(),
         savedStateHandle = savedStateHandle
     )

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -55,19 +55,19 @@ objects.
 ### Create the ViewModel
 
 1. Implement the
-   [ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+   [OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
    interface
-1. Override the `container` field and use the `ViewModel.container` factory
+1. Override the `container` field and use the `ViewModel.orbitContainer` factory
    function to build an Orbit
-   [Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+   [OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
    in your
-   [ContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container-host/)
+   [OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/)
 
 ```kotlin
-class CalculatorViewModel: ContainerHost<CalculatorState, CalculatorSideEffect>, ViewModel() {
+class CalculatorViewModel: OrbitContainerHost<CalculatorState, CalculatorState, CalculatorSideEffect>, ViewModel() {
 
     // Include `orbit-viewmodel` for the factory function
-    override val container = container<CalculatorState, CalculatorSideEffect>(CalculatorState())
+    override val container = orbitContainer<CalculatorState, CalculatorSideEffect>(CalculatorState())
 
     fun add(number: Int) = intent {
         postSideEffect(CalculatorSideEffect.Toast("Adding $number to ${state.total}!"))
@@ -81,7 +81,7 @@ class CalculatorViewModel: ContainerHost<CalculatorState, CalculatorSideEffect>,
 
 We have used an Android `ViewModel` as the most common example, but it's not
 required. You can host an Orbit
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)
 in a simple Kotlin class if you wish. This makes it possible to use in UI
 independent components as well as Kotlin Multiplatform projects.
 
@@ -89,7 +89,7 @@ independent components as well as Kotlin Multiplatform projects.
 
 On Android, we expose an easy one-liner function to connect your UI to the
 ViewModel. Alternatively, you can use the
-[Container](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-container/)'s
+[OrbitContainer](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container/)'s
 `Flow`s directly.
 
 ```kotlin


### PR DESCRIPTION
## Summary

- Updates all markdown documentation to reflect the unified API introduced in #320
- Renames `ContainerHost` → `OrbitContainerHost`, `Container` → `OrbitContainer`, and `container()` → `orbitContainer()` across all code examples, prose, dokka links, and mermaid diagrams
- Rewrites the `ContainerHostWithExternalState` section as "External state", showing the new `OrbitContainerHost<IS, ES, SE>` approach with `transformState` passed directly to `orbitContainer()`

## Test plan

- [ ] Verify markdown renders correctly on the docs site
- [ ] Grep for any remaining references to old API names

🤖 Assisted by [Claude Code](https://claude.com/claude-code)