### PR TITLE
Add broadcast side effect mode for multi-consumer support

### DIFF
--- a/orbit-core/abi/validation/orbit-core.api
+++ b/orbit-core/abi/validation/orbit-core.api
@@ -78,16 +78,18 @@ public final class org/orbitmvi/orbit/OrbitContainerHost$DefaultImpls {
 
 public final class org/orbitmvi/orbit/RealSettings {
 	public fun <init> ()V
-	public fun <init> (ILorg/orbitmvi/orbit/idling/IdlingResource;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineExceptionHandler;J)V
-	public synthetic fun <init> (ILorg/orbitmvi/orbit/idling/IdlingResource;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineExceptionHandler;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILorg/orbitmvi/orbit/idling/IdlingResource;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineExceptionHandler;JLorg/orbitmvi/orbit/SideEffectMode;J)V
+	public synthetic fun <init> (ILorg/orbitmvi/orbit/idling/IdlingResource;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineExceptionHandler;JLorg/orbitmvi/orbit/SideEffectMode;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Lorg/orbitmvi/orbit/idling/IdlingResource;
 	public final fun component3 ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun component4 ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun component5 ()Lkotlinx/coroutines/CoroutineExceptionHandler;
 	public final fun component6 ()J
-	public final fun copy (ILorg/orbitmvi/orbit/idling/IdlingResource;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineExceptionHandler;J)Lorg/orbitmvi/orbit/RealSettings;
-	public static synthetic fun copy$default (Lorg/orbitmvi/orbit/RealSettings;ILorg/orbitmvi/orbit/idling/IdlingResource;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineExceptionHandler;JILjava/lang/Object;)Lorg/orbitmvi/orbit/RealSettings;
+	public final fun component7 ()Lorg/orbitmvi/orbit/SideEffectMode;
+	public final fun component8 ()J
+	public final fun copy (ILorg/orbitmvi/orbit/idling/IdlingResource;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineExceptionHandler;JLorg/orbitmvi/orbit/SideEffectMode;J)Lorg/orbitmvi/orbit/RealSettings;
+	public static synthetic fun copy$default (Lorg/orbitmvi/orbit/RealSettings;ILorg/orbitmvi/orbit/idling/IdlingResource;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineExceptionHandler;JLorg/orbitmvi/orbit/SideEffectMode;JILjava/lang/Object;)Lorg/orbitmvi/orbit/RealSettings;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEventLoopDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getExceptionHandler ()Lkotlinx/coroutines/CoroutineExceptionHandler;
@@ -95,6 +97,8 @@ public final class org/orbitmvi/orbit/RealSettings {
 	public final fun getIntentLaunchingDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getRepeatOnSubscribedStopTimeout ()J
 	public final fun getSideEffectBufferSize ()I
+	public final fun getSideEffectMode ()Lorg/orbitmvi/orbit/SideEffectMode;
+	public final fun getSideEffectReplayClearDelayMs ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -105,10 +109,22 @@ public final class org/orbitmvi/orbit/SettingsBuilder {
 	public final fun getIdlingRegistry ()Lorg/orbitmvi/orbit/idling/IdlingResource;
 	public final fun getRepeatOnSubscribedStopTimeout ()J
 	public final fun getSideEffectBufferSize ()I
+	public final fun getSideEffectMode ()Lorg/orbitmvi/orbit/SideEffectMode;
+	public final fun getSideEffectReplayClearDelayMs ()J
 	public final fun setExceptionHandler (Lkotlinx/coroutines/CoroutineExceptionHandler;)V
 	public final fun setIdlingRegistry (Lorg/orbitmvi/orbit/idling/IdlingResource;)V
 	public final fun setRepeatOnSubscribedStopTimeout (J)V
 	public final fun setSideEffectBufferSize (I)V
+	public final fun setSideEffectMode (Lorg/orbitmvi/orbit/SideEffectMode;)V
+	public final fun setSideEffectReplayClearDelayMs (J)V
+}
+
+public final class org/orbitmvi/orbit/SideEffectMode : java/lang/Enum {
+	public static final field BROADCAST Lorg/orbitmvi/orbit/SideEffectMode;
+	public static final field FAN_OUT Lorg/orbitmvi/orbit/SideEffectMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/orbitmvi/orbit/SideEffectMode;
+	public static fun values ()[Lorg/orbitmvi/orbit/SideEffectMode;
 }
 
 public abstract interface annotation class org/orbitmvi/orbit/annotation/OrbitDsl : java/lang/annotation/Annotation {

--- a/orbit-core/abi/validation/orbit-core.klib.api
+++ b/orbit-core/abi/validation/orbit-core.klib.api
@@ -19,6 +19,17 @@ open annotation class org.orbitmvi.orbit.annotation/OrbitInternal : kotlin/Annot
     constructor <init>() // org.orbitmvi.orbit.annotation/OrbitInternal.<init>|<init>(){}[0]
 }
 
+final enum class org.orbitmvi.orbit/SideEffectMode : kotlin/Enum<org.orbitmvi.orbit/SideEffectMode> { // org.orbitmvi.orbit/SideEffectMode|null[0]
+    enum entry BROADCAST // org.orbitmvi.orbit/SideEffectMode.BROADCAST|null[0]
+    enum entry FAN_OUT // org.orbitmvi.orbit/SideEffectMode.FAN_OUT|null[0]
+
+    final val entries // org.orbitmvi.orbit/SideEffectMode.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<org.orbitmvi.orbit/SideEffectMode> // org.orbitmvi.orbit/SideEffectMode.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): org.orbitmvi.orbit/SideEffectMode // org.orbitmvi.orbit/SideEffectMode.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<org.orbitmvi.orbit/SideEffectMode> // org.orbitmvi.orbit/SideEffectMode.values|values#static(){}[0]
+}
+
 abstract interface <#A: kotlin/Any, #B: kotlin/Any, #C: kotlin/Any> org.orbitmvi.orbit/OrbitContainer { // org.orbitmvi.orbit/OrbitContainer|null[0]
     abstract val externalRefCountStateFlow // org.orbitmvi.orbit/OrbitContainer.externalRefCountStateFlow|{}externalRefCountStateFlow[0]
         abstract fun <get-externalRefCountStateFlow>(): kotlinx.coroutines.flow/StateFlow<#B> // org.orbitmvi.orbit/OrbitContainer.externalRefCountStateFlow.<get-externalRefCountStateFlow>|<get-externalRefCountStateFlow>(){}[0]
@@ -135,7 +146,7 @@ final class org.orbitmvi.orbit.idling/NoopIdlingResource : org.orbitmvi.orbit.id
 }
 
 final class org.orbitmvi.orbit/RealSettings { // org.orbitmvi.orbit/RealSettings|null[0]
-    constructor <init>(kotlin/Int = ..., org.orbitmvi.orbit.idling/IdlingResource = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlinx.coroutines/CoroutineExceptionHandler? = ..., kotlin/Long = ...) // org.orbitmvi.orbit/RealSettings.<init>|<init>(kotlin.Int;org.orbitmvi.orbit.idling.IdlingResource;kotlinx.coroutines.CoroutineDispatcher;kotlinx.coroutines.CoroutineDispatcher;kotlinx.coroutines.CoroutineExceptionHandler?;kotlin.Long){}[0]
+    constructor <init>(kotlin/Int = ..., org.orbitmvi.orbit.idling/IdlingResource = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlinx.coroutines/CoroutineExceptionHandler? = ..., kotlin/Long = ..., org.orbitmvi.orbit/SideEffectMode = ..., kotlin/Long = ...) // org.orbitmvi.orbit/RealSettings.<init>|<init>(kotlin.Int;org.orbitmvi.orbit.idling.IdlingResource;kotlinx.coroutines.CoroutineDispatcher;kotlinx.coroutines.CoroutineDispatcher;kotlinx.coroutines.CoroutineExceptionHandler?;kotlin.Long;org.orbitmvi.orbit.SideEffectMode;kotlin.Long){}[0]
 
     final val eventLoopDispatcher // org.orbitmvi.orbit/RealSettings.eventLoopDispatcher|{}eventLoopDispatcher[0]
         final fun <get-eventLoopDispatcher>(): kotlinx.coroutines/CoroutineDispatcher // org.orbitmvi.orbit/RealSettings.eventLoopDispatcher.<get-eventLoopDispatcher>|<get-eventLoopDispatcher>(){}[0]
@@ -149,6 +160,10 @@ final class org.orbitmvi.orbit/RealSettings { // org.orbitmvi.orbit/RealSettings
         final fun <get-repeatOnSubscribedStopTimeout>(): kotlin/Long // org.orbitmvi.orbit/RealSettings.repeatOnSubscribedStopTimeout.<get-repeatOnSubscribedStopTimeout>|<get-repeatOnSubscribedStopTimeout>(){}[0]
     final val sideEffectBufferSize // org.orbitmvi.orbit/RealSettings.sideEffectBufferSize|{}sideEffectBufferSize[0]
         final fun <get-sideEffectBufferSize>(): kotlin/Int // org.orbitmvi.orbit/RealSettings.sideEffectBufferSize.<get-sideEffectBufferSize>|<get-sideEffectBufferSize>(){}[0]
+    final val sideEffectMode // org.orbitmvi.orbit/RealSettings.sideEffectMode|{}sideEffectMode[0]
+        final fun <get-sideEffectMode>(): org.orbitmvi.orbit/SideEffectMode // org.orbitmvi.orbit/RealSettings.sideEffectMode.<get-sideEffectMode>|<get-sideEffectMode>(){}[0]
+    final val sideEffectReplayClearDelayMs // org.orbitmvi.orbit/RealSettings.sideEffectReplayClearDelayMs|{}sideEffectReplayClearDelayMs[0]
+        final fun <get-sideEffectReplayClearDelayMs>(): kotlin/Long // org.orbitmvi.orbit/RealSettings.sideEffectReplayClearDelayMs.<get-sideEffectReplayClearDelayMs>|<get-sideEffectReplayClearDelayMs>(){}[0]
 
     final fun component1(): kotlin/Int // org.orbitmvi.orbit/RealSettings.component1|component1(){}[0]
     final fun component2(): org.orbitmvi.orbit.idling/IdlingResource // org.orbitmvi.orbit/RealSettings.component2|component2(){}[0]
@@ -156,7 +171,9 @@ final class org.orbitmvi.orbit/RealSettings { // org.orbitmvi.orbit/RealSettings
     final fun component4(): kotlinx.coroutines/CoroutineDispatcher // org.orbitmvi.orbit/RealSettings.component4|component4(){}[0]
     final fun component5(): kotlinx.coroutines/CoroutineExceptionHandler? // org.orbitmvi.orbit/RealSettings.component5|component5(){}[0]
     final fun component6(): kotlin/Long // org.orbitmvi.orbit/RealSettings.component6|component6(){}[0]
-    final fun copy(kotlin/Int = ..., org.orbitmvi.orbit.idling/IdlingResource = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlinx.coroutines/CoroutineExceptionHandler? = ..., kotlin/Long = ...): org.orbitmvi.orbit/RealSettings // org.orbitmvi.orbit/RealSettings.copy|copy(kotlin.Int;org.orbitmvi.orbit.idling.IdlingResource;kotlinx.coroutines.CoroutineDispatcher;kotlinx.coroutines.CoroutineDispatcher;kotlinx.coroutines.CoroutineExceptionHandler?;kotlin.Long){}[0]
+    final fun component7(): org.orbitmvi.orbit/SideEffectMode // org.orbitmvi.orbit/RealSettings.component7|component7(){}[0]
+    final fun component8(): kotlin/Long // org.orbitmvi.orbit/RealSettings.component8|component8(){}[0]
+    final fun copy(kotlin/Int = ..., org.orbitmvi.orbit.idling/IdlingResource = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlinx.coroutines/CoroutineDispatcher = ..., kotlinx.coroutines/CoroutineExceptionHandler? = ..., kotlin/Long = ..., org.orbitmvi.orbit/SideEffectMode = ..., kotlin/Long = ...): org.orbitmvi.orbit/RealSettings // org.orbitmvi.orbit/RealSettings.copy|copy(kotlin.Int;org.orbitmvi.orbit.idling.IdlingResource;kotlinx.coroutines.CoroutineDispatcher;kotlinx.coroutines.CoroutineDispatcher;kotlinx.coroutines.CoroutineExceptionHandler?;kotlin.Long;org.orbitmvi.orbit.SideEffectMode;kotlin.Long){}[0]
     final fun equals(kotlin/Any?): kotlin/Boolean // org.orbitmvi.orbit/RealSettings.equals|equals(kotlin.Any?){}[0]
     final fun hashCode(): kotlin/Int // org.orbitmvi.orbit/RealSettings.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // org.orbitmvi.orbit/RealSettings.toString|toString(){}[0]
@@ -177,6 +194,12 @@ final class org.orbitmvi.orbit/SettingsBuilder { // org.orbitmvi.orbit/SettingsB
     final var sideEffectBufferSize // org.orbitmvi.orbit/SettingsBuilder.sideEffectBufferSize|{}sideEffectBufferSize[0]
         final fun <get-sideEffectBufferSize>(): kotlin/Int // org.orbitmvi.orbit/SettingsBuilder.sideEffectBufferSize.<get-sideEffectBufferSize>|<get-sideEffectBufferSize>(){}[0]
         final fun <set-sideEffectBufferSize>(kotlin/Int) // org.orbitmvi.orbit/SettingsBuilder.sideEffectBufferSize.<set-sideEffectBufferSize>|<set-sideEffectBufferSize>(kotlin.Int){}[0]
+    final var sideEffectMode // org.orbitmvi.orbit/SettingsBuilder.sideEffectMode|{}sideEffectMode[0]
+        final fun <get-sideEffectMode>(): org.orbitmvi.orbit/SideEffectMode // org.orbitmvi.orbit/SettingsBuilder.sideEffectMode.<get-sideEffectMode>|<get-sideEffectMode>(){}[0]
+        final fun <set-sideEffectMode>(org.orbitmvi.orbit/SideEffectMode) // org.orbitmvi.orbit/SettingsBuilder.sideEffectMode.<set-sideEffectMode>|<set-sideEffectMode>(org.orbitmvi.orbit.SideEffectMode){}[0]
+    final var sideEffectReplayClearDelayMs // org.orbitmvi.orbit/SettingsBuilder.sideEffectReplayClearDelayMs|{}sideEffectReplayClearDelayMs[0]
+        final fun <get-sideEffectReplayClearDelayMs>(): kotlin/Long // org.orbitmvi.orbit/SettingsBuilder.sideEffectReplayClearDelayMs.<get-sideEffectReplayClearDelayMs>|<get-sideEffectReplayClearDelayMs>(){}[0]
+        final fun <set-sideEffectReplayClearDelayMs>(kotlin/Long) // org.orbitmvi.orbit/SettingsBuilder.sideEffectReplayClearDelayMs.<set-sideEffectReplayClearDelayMs>|<set-sideEffectReplayClearDelayMs>(kotlin.Long){}[0]
 }
 
 final fun <#A: kotlin/Any, #B: kotlin/Any, #C: kotlin/Any> (kotlinx.coroutines/CoroutineScope).org.orbitmvi.orbit/container(#A, kotlin/Function1<#A, #B>, kotlin/Function1<org.orbitmvi.orbit/SettingsBuilder, kotlin/Unit> = ..., kotlin.coroutines/SuspendFunction1<org.orbitmvi.orbit.syntax/Syntax<#A, #C>, kotlin/Unit>? = ...): org.orbitmvi.orbit/OrbitContainer<#A, #B, #C> // org.orbitmvi.orbit/container|container@kotlinx.coroutines.CoroutineScope(0:0;kotlin.Function1<0:0,0:1>;kotlin.Function1<org.orbitmvi.orbit.SettingsBuilder,kotlin.Unit>;kotlin.coroutines.SuspendFunction1<org.orbitmvi.orbit.syntax.Syntax<0:0,0:2>,kotlin.Unit>?){0§<kotlin.Any>;1§<kotlin.Any>;2§<kotlin.Any>}[0]

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
@@ -78,12 +78,12 @@ public interface OrbitContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE
     /**
      * A [Flow] of one-off side effects posted from [OrbitContainer]. Caches side effects when there are no collectors.
      * The size of the cache can be controlled via [SettingsBuilder] and determines if and when the orbit thread suspends when you
-     * post a side effect. The default is unlimited. You don't have to touch this unless you are posting many side effects which could result in
-     * `OutOfMemoryError`.
+     * post a side effect.
      *
-     * This is designed to be collected by one observer only in order to ensure that side effect caching works in a predictable way.
-     * If your particular use case requires multi-casting use `broadcast` on this [Flow], but be aware that caching will not work for the
-     * resulting `BroadcastChannel`.
+     * The delivery behavior depends on [SideEffectMode]:
+     * - [SideEffectMode.FAN_OUT]: Each side effect is delivered to exactly one collector. Designed for single-observer use.
+     * - [SideEffectMode.BROADCAST]: Side effects are broadcast to all active collectors. Cached side effects are replayed
+     *   to all collectors when they reconnect. The replay cache is cleared shortly after subscribers reconnect.
      */
     public val sideEffectFlow: Flow<SIDE_EFFECT>
 
@@ -91,16 +91,14 @@ public interface OrbitContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE
      * A version of [sideEffectFlow] ref-counted for the [Syntax.repeatOnSubscription] operator.
      * Do not use when subscribing to state updates within your [OrbitContainerHost].
      *
-     * [Flow] of one-off side effects posted from [OrbitContainer]. Caches side effects when there are no collectors.
+     * A [Flow] of one-off side effects posted from [OrbitContainer]. Caches side effects when there are no collectors.
      * The size of the cache can be controlled via [SettingsBuilder] and determines if and when the orbit thread suspends when you
-     * post a side effect. The default is unlimited. You don't have to touch this unless you are posting many side effects which could result in
-     * `OutOfMemoryError`.
+     * post a side effect.
      *
-     * This is designed to be collected by one observer only in order to ensure that side effect caching works in a predictable way.
-     * If your particular use case requires multi-casting use `broadcast` on this [Flow], but be aware that caching will not work for the
-     * resulting `BroadcastChannel`.
-     *
-     *  It's the same as [sideEffectFlow], but it's ref-counted for the [Syntax.repeatOnSubscription] operator.
+     * The delivery behavior depends on [SideEffectMode]:
+     * - [SideEffectMode.FAN_OUT]: Each side effect is delivered to exactly one collector. Designed for single-observer use.
+     * - [SideEffectMode.BROADCAST]: Side effects are broadcast to all active collectors. Cached side effects are replayed
+     *   to all collectors when they reconnect. The replay cache is cleared shortly after subscribers reconnect.
      */
     public val refCountSideEffectFlow: Flow<SIDE_EFFECT>
 

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Container.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2026 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
@@ -22,6 +22,24 @@ import kotlinx.coroutines.channels.Channel
 import org.orbitmvi.orbit.idling.IdlingResource
 import org.orbitmvi.orbit.idling.NoopIdlingResource
 
+/**
+ * Controls how side effects are delivered to collectors.
+ */
+public enum class SideEffectMode {
+    /**
+     * Each side effect is delivered to exactly one collector (fan-out).
+     * Cached side effects are consumed by the first collector that connects.
+     */
+    FAN_OUT,
+
+    /**
+     * Side effects are broadcast to all active collectors.
+     * Cached side effects are replayed to all collectors when they reconnect.
+     * The replay cache is cleared shortly after subscribers reconnect to prevent stale replay.
+     */
+    BROADCAST
+}
+
 public data class RealSettings(
     public val sideEffectBufferSize: Int = Channel.BUFFERED,
     public val idlingRegistry: IdlingResource = NoopIdlingResource(),
@@ -29,6 +47,8 @@ public data class RealSettings(
     public val intentLaunchingDispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
     public val exceptionHandler: CoroutineExceptionHandler? = null,
     public val repeatOnSubscribedStopTimeout: Long = 100L,
+    public val sideEffectMode: SideEffectMode = SideEffectMode.BROADCAST,
+    public val sideEffectReplayClearDelayMs: Long = 100L,
 )
 
 public class SettingsBuilder {
@@ -57,5 +77,17 @@ public class SettingsBuilder {
         get() = settings.sideEffectBufferSize
         public set(value) {
             settings = settings.copy(sideEffectBufferSize = value)
+        }
+
+    public var sideEffectMode: SideEffectMode
+        get() = settings.sideEffectMode
+        public set(value) {
+            settings = settings.copy(sideEffectMode = value)
+        }
+
+    public var sideEffectReplayClearDelayMs: Long
+        get() = settings.sideEffectReplayClearDelayMs
+        public set(value) {
+            settings = settings.copy(sideEffectReplayClearDelayMs = value)
         }
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2022-2026 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -27,11 +27,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -42,8 +45,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import org.orbitmvi.orbit.OrbitContainer
 import org.orbitmvi.orbit.RealSettings
+import org.orbitmvi.orbit.SideEffectMode
 import org.orbitmvi.orbit.internal.repeatonsubscription.DelayingSubscribedCounter
 import org.orbitmvi.orbit.internal.repeatonsubscription.SubscribedCounter
+import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription
 import org.orbitmvi.orbit.internal.repeatonsubscription.refCount
 import org.orbitmvi.orbit.syntax.ContainerContext
 import kotlin.concurrent.atomics.AtomicBoolean
@@ -66,11 +71,21 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
     private val initialised = AtomicBoolean(false)
     private val subscribedCounter = subscribedCounterOverride ?: DelayingSubscribedCounter(scope, settings.repeatOnSubscribedStopTimeout)
     private val internalStateFlow = MutableStateFlow(initialState)
-    private val sideEffectChannel = Channel<SIDE_EFFECT>(settings.sideEffectBufferSize)
     private val intentCounter = AtomicInt(0)
 
+    private val sideEffectSharedFlow: MutableSharedFlow<SIDE_EFFECT>? =
+        if (settings.sideEffectMode == SideEffectMode.BROADCAST)
+            MutableSharedFlow(replay = resolveBufferSize(settings.sideEffectBufferSize), onBufferOverflow = BufferOverflow.SUSPEND)
+        else null
+
+    private val sideEffectChannel: Channel<SIDE_EFFECT>? =
+        if (settings.sideEffectMode == SideEffectMode.FAN_OUT)
+            Channel(settings.sideEffectBufferSize)
+        else null
+
     override val stateFlow: StateFlow<INTERNAL_STATE> = internalStateFlow.asStateFlow()
-    override val sideEffectFlow: Flow<SIDE_EFFECT> = sideEffectChannel.receiveAsFlow()
+    override val sideEffectFlow: Flow<SIDE_EFFECT> =
+        sideEffectSharedFlow ?: sideEffectChannel!!.receiveAsFlow()
 
     override val refCountStateFlow: StateFlow<INTERNAL_STATE> = internalStateFlow.refCount(subscribedCounter)
     override val refCountSideEffectFlow: Flow<SIDE_EFFECT> = sideEffectFlow.refCount(subscribedCounter)
@@ -93,7 +108,7 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
 
     internal val pluginContext: ContainerContext<INTERNAL_STATE, SIDE_EFFECT> = ContainerContext(
         settings = settings,
-        postSideEffect = { sideEffectChannel.send(it) },
+        postSideEffect = { sideEffectSharedFlow?.emit(it) ?: sideEffectChannel!!.send(it) },
         reduce = { reducer -> internalStateFlow.update(reducer) },
         subscribedCounter = subscribedCounter,
         stateFlow = stateFlow,
@@ -134,12 +149,26 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
                     }.invokeOnCompletion { job.complete() }
                 }
             }
+
+            sideEffectSharedFlow?.let { sharedFlow ->
+                scope.launch(CoroutineName(COROUTINE_NAME_REPLAY_CACHE_CLEAR)) {
+                    var previousSubscription = Subscription.Unsubscribed
+                    subscribedCounter.subscribed.collect { subscription ->
+                        if (previousSubscription == Subscription.Unsubscribed && subscription == Subscription.Subscribed) {
+                            delay(settings.sideEffectReplayClearDelayMs)
+                            sharedFlow.resetReplayCache()
+                        }
+                        previousSubscription = subscription
+                    }
+                }
+            }
         }
     }
 
     private companion object {
         private const val COROUTINE_NAME_EVENT_LOOP = "orbit-event-loop"
         private const val COROUTINE_NAME_INTENT = "orbit-intent-"
+        private const val COROUTINE_NAME_REPLAY_CACHE_CLEAR = "orbit-replay-cache-clear"
     }
 }
 
@@ -169,3 +198,5 @@ internal class MappedStateFlow<T : Any, U : Any>(
 
 internal fun <T : Any, U : Any> StateFlow<T>.stateMap(transform: (T) -> U): StateFlow<U> =
     MappedStateFlow(this, transform)
+
+private fun resolveBufferSize(size: Int): Int = if (size < 0) 64 else size

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -74,14 +74,18 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
     private val intentCounter = AtomicInt(0)
 
     private val sideEffectSharedFlow: MutableSharedFlow<SIDE_EFFECT>? =
-        if (settings.sideEffectMode == SideEffectMode.BROADCAST)
+        if (settings.sideEffectMode == SideEffectMode.BROADCAST) {
             MutableSharedFlow(replay = resolveBufferSize(settings.sideEffectBufferSize), onBufferOverflow = BufferOverflow.SUSPEND)
-        else null
+        } else {
+            null
+        }
 
     private val sideEffectChannel: Channel<SIDE_EFFECT>? =
-        if (settings.sideEffectMode == SideEffectMode.FAN_OUT)
+        if (settings.sideEffectMode == SideEffectMode.FAN_OUT) {
             Channel(settings.sideEffectBufferSize)
-        else null
+        } else {
+            null
+        }
 
     override val stateFlow: StateFlow<INTERNAL_STATE> = internalStateFlow.asStateFlow()
     override val sideEffectFlow: Flow<SIDE_EFFECT> =

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -199,4 +199,6 @@ internal class MappedStateFlow<T : Any, U : Any>(
 internal fun <T : Any, U : Any> StateFlow<T>.stateMap(transform: (T) -> U): StateFlow<U> =
     MappedStateFlow(this, transform)
 
-private fun resolveBufferSize(size: Int): Int = if (size < 0) 64 else size
+private const val DEFAULT_BUFFER_SIZE = 64
+
+private fun resolveBufferSize(size: Int): Int = if (size < 0) DEFAULT_BUFFER_SIZE else size

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -27,28 +27,22 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.produce
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import org.orbitmvi.orbit.OrbitContainer
 import org.orbitmvi.orbit.RealSettings
-import org.orbitmvi.orbit.SideEffectMode
 import org.orbitmvi.orbit.internal.repeatonsubscription.DelayingSubscribedCounter
 import org.orbitmvi.orbit.internal.repeatonsubscription.SubscribedCounter
-import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription
 import org.orbitmvi.orbit.internal.repeatonsubscription.refCount
 import org.orbitmvi.orbit.syntax.ContainerContext
 import kotlin.concurrent.atomics.AtomicBoolean
@@ -73,23 +67,10 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
     private val internalStateFlow = MutableStateFlow(initialState)
     private val intentCounter = AtomicInt(0)
 
-    private val sideEffectSharedFlow: MutableSharedFlow<SIDE_EFFECT>? =
-        if (settings.sideEffectMode == SideEffectMode.BROADCAST) {
-            MutableSharedFlow(replay = resolveBufferSize(settings.sideEffectBufferSize), onBufferOverflow = BufferOverflow.SUSPEND)
-        } else {
-            null
-        }
-
-    private val sideEffectChannel: Channel<SIDE_EFFECT>? =
-        if (settings.sideEffectMode == SideEffectMode.FAN_OUT) {
-            Channel(settings.sideEffectBufferSize)
-        } else {
-            null
-        }
+    private val sideEffectProvider: SideEffectProvider<SIDE_EFFECT> = SideEffectProvider.create(settings)
 
     override val stateFlow: StateFlow<INTERNAL_STATE> = internalStateFlow.asStateFlow()
-    override val sideEffectFlow: Flow<SIDE_EFFECT> =
-        sideEffectSharedFlow ?: sideEffectChannel!!.receiveAsFlow()
+    override val sideEffectFlow: Flow<SIDE_EFFECT> = sideEffectProvider.sideEffectFlow
 
     override val refCountStateFlow: StateFlow<INTERNAL_STATE> = internalStateFlow.refCount(subscribedCounter)
     override val refCountSideEffectFlow: Flow<SIDE_EFFECT> = sideEffectFlow.refCount(subscribedCounter)
@@ -112,7 +93,7 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
 
     internal val pluginContext: ContainerContext<INTERNAL_STATE, SIDE_EFFECT> = ContainerContext(
         settings = settings,
-        postSideEffect = { sideEffectSharedFlow?.emit(it) ?: sideEffectChannel!!.send(it) },
+        postSideEffect = sideEffectProvider::postSideEffect,
         reduce = { reducer -> internalStateFlow.update(reducer) },
         subscribedCounter = subscribedCounter,
         stateFlow = stateFlow,
@@ -154,17 +135,8 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
                 }
             }
 
-            sideEffectSharedFlow?.let { sharedFlow ->
-                scope.launch(CoroutineName(COROUTINE_NAME_REPLAY_CACHE_CLEAR)) {
-                    var previousSubscription = Subscription.Unsubscribed
-                    subscribedCounter.subscribed.collect { subscription ->
-                        if (previousSubscription == Subscription.Unsubscribed && subscription == Subscription.Subscribed) {
-                            delay(settings.sideEffectReplayClearDelayMs)
-                            sharedFlow.resetReplayCache()
-                        }
-                        previousSubscription = subscription
-                    }
-                }
+            scope.launch(CoroutineName(COROUTINE_NAME_REPLAY_CACHE_CLEAR)) {
+                sideEffectProvider.initialise(subscribedCounter)
             }
         }
     }
@@ -202,7 +174,3 @@ internal class MappedStateFlow<T : Any, U : Any>(
 
 internal fun <T : Any, U : Any> StateFlow<T>.stateMap(transform: (T) -> U): StateFlow<U> =
     MappedStateFlow(this, transform)
-
-private const val DEFAULT_BUFFER_SIZE = 64
-
-private fun resolveBufferSize(size: Int): Int = if (size < 0) DEFAULT_BUFFER_SIZE else size

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2026 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/SideEffectProvider.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/SideEffectProvider.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit.internal
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import org.orbitmvi.orbit.RealSettings
+import org.orbitmvi.orbit.SideEffectMode
+import org.orbitmvi.orbit.internal.repeatonsubscription.SubscribedCounter
+import org.orbitmvi.orbit.internal.repeatonsubscription.Subscription
+
+internal interface SideEffectProvider<SIDE_EFFECT> {
+    val sideEffectFlow: Flow<SIDE_EFFECT>
+
+    suspend fun postSideEffect(sideEffect: SIDE_EFFECT)
+
+    suspend fun initialise(subscribedCounter: SubscribedCounter)
+
+    companion object {
+        fun <SIDE_EFFECT> create(settings: RealSettings): SideEffectProvider<SIDE_EFFECT> =
+            when (settings.sideEffectMode) {
+                SideEffectMode.FAN_OUT -> FanOutSideEffectProvider(settings)
+                SideEffectMode.BROADCAST -> BroadcastSideEffectProvider(settings)
+            }
+    }
+}
+
+private class FanOutSideEffectProvider<SIDE_EFFECT>(
+    settings: RealSettings,
+) : SideEffectProvider<SIDE_EFFECT> {
+    private val channel = Channel<SIDE_EFFECT>(settings.sideEffectBufferSize)
+
+    override val sideEffectFlow: Flow<SIDE_EFFECT> = channel.receiveAsFlow()
+
+    override suspend fun postSideEffect(sideEffect: SIDE_EFFECT) {
+        channel.send(sideEffect)
+    }
+
+    override suspend fun initialise(subscribedCounter: SubscribedCounter) = Unit
+}
+
+private class BroadcastSideEffectProvider<SIDE_EFFECT>(
+    private val settings: RealSettings,
+) : SideEffectProvider<SIDE_EFFECT> {
+    private val sharedFlow = MutableSharedFlow<SIDE_EFFECT>(
+        replay = resolveBufferSize(settings.sideEffectBufferSize),
+        onBufferOverflow = BufferOverflow.SUSPEND,
+    )
+
+    override val sideEffectFlow: Flow<SIDE_EFFECT> = sharedFlow
+
+    override suspend fun postSideEffect(sideEffect: SIDE_EFFECT) {
+        sharedFlow.emit(sideEffect)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override suspend fun initialise(subscribedCounter: SubscribedCounter) {
+        var previousSubscription = Subscription.Unsubscribed
+        subscribedCounter.subscribed.collect { subscription ->
+            if (previousSubscription == Subscription.Unsubscribed && subscription == Subscription.Subscribed) {
+                delay(settings.sideEffectReplayClearDelayMs)
+                sharedFlow.resetReplayCache()
+            }
+            previousSubscription = subscription
+        }
+    }
+}
+
+private const val DEFAULT_BUFFER_SIZE = 64
+
+private fun resolveBufferSize(size: Int): Int =
+    if (size < 0) DEFAULT_BUFFER_SIZE else size

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/BroadcastSideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/BroadcastSideEffectTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2025 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit.internal
+
+import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.orbitmvi.orbit.OrbitContainer
+import org.orbitmvi.orbit.SideEffectMode
+import org.orbitmvi.orbit.orbitContainer
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class BroadcastSideEffectTest {
+
+    @Test
+    fun side_effects_are_emitted_in_order() = runTest {
+        val container = createContainer()
+
+        container.sideEffectFlow.test {
+            repeat(1000) {
+                container.someFlow(it)
+            }
+
+            repeat(1000) {
+                assertEquals(it, awaitItem())
+            }
+        }
+    }
+
+    @Test
+    fun side_effects_are_cached_when_there_are_no_subscribers() = runTest {
+        val action = Random.nextInt()
+        val action2 = Random.nextInt()
+        val action3 = Random.nextInt()
+        val container = createContainer()
+
+        joinAll(
+            container.someFlow(action),
+            container.someFlow(action2),
+            container.someFlow(action3)
+        )
+
+        container.sideEffectFlow.test {
+            assertEquals(action, awaitItem())
+            assertEquals(action2, awaitItem())
+            assertEquals(action3, awaitItem())
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun cached_side_effects_are_delivered_to_all_consumers() = runTest {
+        val action = Random.nextInt()
+        val action2 = Random.nextInt()
+        val action3 = Random.nextInt()
+        val container = createContainer()
+
+        joinAll(
+            container.someFlow(action),
+            container.someFlow(action2),
+            container.someFlow(action3)
+        )
+
+        // Both consumers should receive all cached side effects
+        launch {
+            container.sideEffectFlow.test {
+                assertEquals(action, awaitItem())
+                assertEquals(action2, awaitItem())
+                assertEquals(action3, awaitItem())
+                ensureAllEventsConsumed()
+                cancel()
+            }
+        }
+
+        launch {
+            container.sideEffectFlow.test {
+                assertEquals(action, awaitItem())
+                assertEquals(action2, awaitItem())
+                assertEquals(action3, awaitItem())
+                ensureAllEventsConsumed()
+                cancel()
+            }
+        }
+    }
+
+    @Test
+    fun live_side_effects_are_delivered_to_all_consumers() = runTest {
+        val container = createContainer()
+        val received1 = mutableListOf<Int>()
+        val received2 = mutableListOf<Int>()
+
+        val job1 = launch {
+            container.sideEffectFlow.collect { received1.add(it) }
+        }
+        val job2 = launch {
+            container.sideEffectFlow.collect { received2.add(it) }
+        }
+
+        // Let collectors start
+        advanceUntilIdle()
+
+        joinAll(
+            container.someFlow(1),
+            container.someFlow(2),
+            container.someFlow(3)
+        )
+
+        advanceUntilIdle()
+
+        assertEquals(listOf(1, 2, 3), received1)
+        assertEquals(listOf(1, 2, 3), received2)
+
+        job1.cancel()
+        job2.cancel()
+    }
+
+    @Test
+    fun cached_side_effects_are_replayed_to_new_subscriber() = runTest {
+        val action = Random.nextInt()
+        val container = createContainer()
+
+        container.sideEffectFlow.test {
+            container.someFlow(action)
+            assertEquals(action, awaitItem())
+            ensureAllEventsConsumed()
+            cancel()
+        }
+
+        // In broadcast mode, the replay cache still contains the side effect
+        // (sideEffectFlow does not trigger ref-count, so no resetReplayCache)
+        container.sideEffectFlow.test {
+            assertEquals(action, awaitItem())
+            cancel()
+        }
+    }
+
+    @Test
+    fun replay_cache_is_cleared_after_ref_count_subscription() = runTest {
+        val action = Random.nextInt()
+        val container = createContainer()
+
+        container.someFlow(action)
+
+        // Subscribe via refCountSideEffectFlow to trigger the subscribed counter
+        container.refCountSideEffectFlow.test {
+            assertEquals(action, awaitItem())
+            cancel()
+        }
+
+        // The replay clear runs on Dispatchers.Default (not the test dispatcher),
+        // so we need to wait real wall-clock time for it to complete.
+        withContext(Dispatchers.Default) { delay(300) }
+
+        // After replay cache clear, new subscriber should not see stale items
+        container.sideEffectFlow.test {
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    private fun TestScope.createContainer(): OrbitContainer<Unit, Unit, Int> =
+        backgroundScope.orbitContainer(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.BROADCAST }
+        )
+
+    private suspend fun OrbitContainer<Unit, Unit, Int>.someFlow(action: Int) = orbit {
+        postSideEffect(action)
+    }
+}

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/BroadcastSideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/BroadcastSideEffectTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2026 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountSideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountSideEffectTest.kt
@@ -22,6 +22,7 @@ package org.orbitmvi.orbit.internal
 import app.cash.turbine.test
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.OrbitContainer
+import org.orbitmvi.orbit.SideEffectMode
 import org.orbitmvi.orbit.orbitContainer
 import kotlin.random.Random
 import kotlin.test.Test
@@ -31,7 +32,10 @@ internal class RefCountSideEffectTest {
 
     @Test
     fun side_effects_are_emitted_in_order() = runTest {
-        val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
+        val container = backgroundScope.orbitContainer<Unit, Int>(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.FAN_OUT }
+        )
 
         container.refCountSideEffectFlow.test {
             repeat(1000) {
@@ -46,7 +50,10 @@ internal class RefCountSideEffectTest {
 
     @Test
     fun side_effects_are_cached_when_there_are_no_subscribers() = runTest {
-        val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
+        val container = backgroundScope.orbitContainer<Unit, Int>(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.FAN_OUT }
+        )
         val action = Random.nextInt()
         val action2 = Random.nextInt()
         val action3 = Random.nextInt()
@@ -64,7 +71,10 @@ internal class RefCountSideEffectTest {
 
     @Test
     fun consumed_side_effects_are_not_resent() = runTest {
-        val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
+        val container = backgroundScope.orbitContainer<Unit, Int>(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.FAN_OUT }
+        )
         val action = Random.nextInt()
         val action2 = Random.nextInt()
         val action3 = Random.nextInt()
@@ -85,7 +95,10 @@ internal class RefCountSideEffectTest {
 
     @Test
     fun only_new_side_effects_are_emitted_when_resubscribing() = runTest {
-        val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
+        val container = backgroundScope.orbitContainer<Unit, Int>(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.FAN_OUT }
+        )
         val action = Random.nextInt()
 
         container.refCountSideEffectFlow.test {

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountSideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountSideEffectTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2024-2026 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SideEffectTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.OrbitContainer
+import org.orbitmvi.orbit.SideEffectMode
 import org.orbitmvi.orbit.orbitContainer
 import kotlin.random.Random
 import kotlin.test.Test
@@ -34,7 +35,10 @@ internal class SideEffectTest {
 
     @Test
     fun side_effects_are_emitted_in_order() = runTest {
-        val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
+        val container = backgroundScope.orbitContainer<Unit, Int>(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.FAN_OUT }
+        )
 
         container.sideEffectFlow.test {
             repeat(1000) {
@@ -52,7 +56,10 @@ internal class SideEffectTest {
         val action = Random.nextInt()
         val action2 = Random.nextInt()
         val action3 = Random.nextInt()
-        val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
+        val container = backgroundScope.orbitContainer<Unit, Int>(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.FAN_OUT }
+        )
 
         joinAll(
             container.someFlow(action),
@@ -73,7 +80,10 @@ internal class SideEffectTest {
         val action = Random.nextInt()
         val action2 = Random.nextInt()
         val action3 = Random.nextInt()
-        val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
+        val container = backgroundScope.orbitContainer<Unit, Int>(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.FAN_OUT }
+        )
 
         joinAll(
             container.someFlow(action),
@@ -98,7 +108,10 @@ internal class SideEffectTest {
     @Test
     fun only_new_side_effects_are_emitted_when_resubscribing() = runTest {
         val action = Random.nextInt()
-        val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
+        val container = backgroundScope.orbitContainer<Unit, Int>(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.FAN_OUT }
+        )
 
         container.sideEffectFlow.test {
             container.someFlow(action)

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SideEffectTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2021-2026 Mikołaj Leszczyński & Appmattus Limited
  * Copyright 2020 Babylon Partners Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/website/docs/Core/index.md
+++ b/website/docs/Core/index.md
@@ -237,13 +237,18 @@ Navigation, etc.
 Side effects are cached if there are no observers, guaranteeing critical
 events such as navigation are delivered after re-subscription.
 
-:::caution
+Delivery behaviour is controlled by `SettingsBuilder.sideEffectMode`:
 
-`Container.sideEffectFlow` is designed for a single observer to ensure
-predictable side effect caching. If you need multiple observers, use `shareIn`,
-but note that caching may not apply to the resulting `SharedFlow`.
-
-:::
+- `SideEffectMode.BROADCAST` (default) — side effects are broadcast to all
+  active collectors, and cached side effects are replayed to every collector
+  that connects. Shortly after the first subscriber connects, the replay cache
+  is cleared so late joiners don't receive stale events. Collectors that take
+  a long time to process items will back-pressure the emitter (and the other
+  collectors) once the buffer fills.
+- `SideEffectMode.FAN_OUT` — legacy single-observer behaviour. Each side effect
+  is delivered to exactly one collector; cached side effects are consumed by
+  the first collector that connects. Use this when you specifically need
+  fan-out semantics.
 
 ### Repeat on subscription
 


### PR DESCRIPTION
## Summary
- Introduce `SideEffectMode` enum (`FAN_OUT` / `BROADCAST`) to control side effect delivery semantics
- `BROADCAST` mode (new default) uses `MutableSharedFlow` with replay — cached side effects are delivered to **all** consumers when they reconnect, and live side effects are broadcast to all active collectors
- `FAN_OUT` mode preserves the existing `Channel`-based fan-out behavior where each side effect goes to exactly one collector
- Replay cache is automatically cleared after subscribers reconnect (configurable via `sideEffectReplayClearDelayMs`) to prevent stale replay
- `postSideEffect` still suspends when the buffer is full in both modes

## Test plan
- [x] Existing `SideEffectTest` passes with explicit `FAN_OUT` mode
- [x] Existing `RefCountSideEffectTest` passes with explicit `FAN_OUT` mode
- [x] New `BroadcastSideEffectTest` covers:
  - Side effects emitted in order
  - Caching when no subscribers
  - Cached side effects delivered to all consumers
  - Live side effects delivered to all consumers
  - Replay cache cleared after ref-count subscription
  - Cached side effects replayed to new subscriber
- [x] ABI validation passes (`apiCheck`)
- [x] JVM and JS test suites pass

🤖 Assisted by [Claude Code](https://claude.com/claude-code)