### PR TITLE
Upgrade Gradle to 9.0 and fix Gradle Kotlin DSL compatibility issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ import com.appmattus.markdown.rules.LineLengthRule
 import com.appmattus.markdown.rules.ProperNamesRule
 import com.appmattus.markdown.rules.ProperNamesRule.Companion.DefaultNames
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+import com.github.benmanes.gradle.versions.updates.resolutionstrategy.ComponentSelectionWithCurrent
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.ZonedDateTime
@@ -57,20 +58,22 @@ tasks.withType<DependencyUpdatesTask> {
     resolutionStrategy {
         componentSelection {
             all {
-                fun isNonStable(version: String) = listOf(
-                    "alpha",
-                    "beta",
-                    "rc",
-                    "cr",
-                    "m",
-                    "preview",
-                    "b",
-                    "ea"
-                ).any { qualifier ->
-                    version.matches(Regex("(?i).*[.-]$qualifier[.\\d-+]*"))
-                }
-                if (isNonStable(candidate.version) && !isNonStable(currentVersion)) {
-                    reject("Release candidate")
+                Action<ComponentSelectionWithCurrent> {
+                    fun isNonStable(version: String) = listOf(
+                        "alpha",
+                        "beta",
+                        "rc",
+                        "cr",
+                        "m",
+                        "preview",
+                        "b",
+                        "ea"
+                    ).any { qualifier ->
+                        version.matches(Regex("(?i).*[.-]$qualifier[.\\d-+]*"))
+                    }
+                    if (isNonStable(candidate.version) && !isNonStable(currentVersion)) {
+                        reject("Release candidate")
+                    }
                 }
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fixes the "red code" in build.gradle.kts that was previously detected by the K2 IDE engine. 
Upgrading to Gradle 9.4 made these errors critical, preventing successful sync. The build script is now fully compatible with Gradle 9.0 and K2.