### PR TITLE
Use consumeAsFlow for side effect channel

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -35,7 +35,7 @@ import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -70,7 +70,7 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
     private val intentCounter = AtomicInt(0)
 
     override val stateFlow: StateFlow<INTERNAL_STATE> = internalStateFlow.asStateFlow()
-    override val sideEffectFlow: Flow<SIDE_EFFECT> = sideEffectChannel.receiveAsFlow()
+    override val sideEffectFlow: Flow<SIDE_EFFECT> = sideEffectChannel.consumeAsFlow()
 
     override val refCountStateFlow: StateFlow<INTERNAL_STATE> = internalStateFlow.refCount(subscribedCounter)
     override val refCountSideEffectFlow: Flow<SIDE_EFFECT> = sideEffectFlow.refCount(subscribedCounter)

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountSideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RefCountSideEffectTest.kt
@@ -26,6 +26,7 @@ import org.orbitmvi.orbit.orbitContainer
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 internal class RefCountSideEffectTest {
 
@@ -77,30 +78,20 @@ internal class RefCountSideEffectTest {
             assertEquals(action2, awaitItem())
             assertEquals(action3, awaitItem())
         }
-
-        container.refCountSideEffectFlow.test {
-            expectNoEvents()
-        }
     }
 
     @Test
-    fun only_new_side_effects_are_emitted_when_resubscribing() = runTest {
+    fun collecting_ref_count_side_effect_flow_more_than_once_throws() = runTest {
         val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
-        val action = Random.nextInt()
 
         container.refCountSideEffectFlow.test {
-            container.someFlow(action)
-            assertEquals(action, awaitItem())
-        }
-
-        repeat(1000) {
-            container.someFlow(it)
+            container.someFlow(1)
+            assertEquals(1, awaitItem())
         }
 
         container.refCountSideEffectFlow.test {
-            repeat(1000) {
-                assertEquals(it, awaitItem())
-            }
+            val error = awaitError()
+            assertIs<IllegalStateException>(error)
         }
     }
 

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SideEffectTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SideEffectTest.kt
@@ -22,13 +22,13 @@ package org.orbitmvi.orbit.internal
 
 import app.cash.turbine.test
 import kotlinx.coroutines.joinAll
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.OrbitContainer
 import org.orbitmvi.orbit.orbitContainer
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 internal class SideEffectTest {
 
@@ -88,37 +88,21 @@ internal class SideEffectTest {
             ensureAllEventsConsumed()
             cancel()
         }
-
-        container.sideEffectFlow.test {
-            expectNoEvents()
-            cancel()
-        }
     }
 
     @Test
-    fun only_new_side_effects_are_emitted_when_resubscribing() = runTest {
-        val action = Random.nextInt()
+    fun collecting_side_effect_flow_more_than_once_throws() = runTest {
         val container = backgroundScope.orbitContainer<Unit, Int>(Unit)
 
         container.sideEffectFlow.test {
-            container.someFlow(action)
-            skipItems(1)
-            ensureAllEventsConsumed()
+            container.someFlow(1)
+            assertEquals(1, awaitItem())
             cancel()
-        }
-
-        launch {
-            repeat(100) {
-                container.someFlow(it)
-            }
         }
 
         container.sideEffectFlow.test {
-            repeat(100) {
-                assertEquals(it, awaitItem())
-            }
-            ensureAllEventsConsumed()
-            cancel()
+            val error = awaitError()
+            assertIs<IllegalStateException>(error)
         }
     }
 


### PR DESCRIPTION
## Summary
- Switches `sideEffectChannel.receiveAsFlow()` to `sideEffectChannel.consumeAsFlow()` in `RealContainer`, enforcing that the side effect flow can only be collected once
- This prevents multiple collectors from silently competing for side effect events — a second collector now gets an `IllegalStateException`
- Updates tests to reflect the new single-collector semantics

Closes #304

## Test plan
- [x] All 69 orbit-core JVM tests pass
- [x] orbit-test and test-common JVM tests pass
- [x] New tests verify `IllegalStateException` on second collection of both `sideEffectFlow` and `refCountSideEffectFlow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)