### PR TITLE
Add awaitRunOn<T> for sealed class states

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/RunOn.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/RunOn.kt
@@ -92,22 +92,7 @@ public suspend inline fun <S : Any, reified T : S> Flow<S>.awaitRunOn(
     crossinline block: suspend (capturedState: T) -> Unit
 ) {
     this.dropWhile { it !is T || !predicate(it) }
-        .transformWhile {
-            if (it is T && predicate(it)) {
-                emit(it)
-                true
-            } else {
-                emit(null)
-                false
-            }
-        }
-        .distinctUntilChangedBy { it != null }
-        .mapLatest {
-            if (it != null) {
-                block(it)
-            }
-        }
-        .firstOrNull()
+        .runOn(predicate, block)
 }
 
 @OrbitInternal

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/RunOn.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/RunOn.kt
@@ -19,6 +19,7 @@ package org.orbitmvi.orbit.syntax
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChangedBy
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.transformWhile
@@ -57,6 +58,49 @@ public suspend inline fun <S : Any, reified T : S> Flow<S>.runOn(
             false
         }
     }
+        .distinctUntilChangedBy { it != null }
+        .mapLatest {
+            if (it != null) {
+                block(it)
+            }
+        }
+        .firstOrNull()
+}
+
+/**
+ * This API is intended to simplify and add type-safety to working with sealed class states.
+ * This can be applied to any [Flow] of states, not just the [OrbitContainer]'s own. The main purpose of this API is to help you
+ * work with child container states.
+ *
+ * Suspends until the state becomes the given subtype and the given [predicate] matches, then executes the given block.
+ *
+ * The block will be cancelled as soon as the state changes to a different type or the predicate does not return true.
+ * Note that this does not guarantee the operation in the block is atomic.
+ *
+ * The state is captured and does not change within this block.
+ *
+ * Unlike [runOn], this function does not complete immediately if the current state does not match.
+ * Instead, it suspends until the state becomes the given subtype.
+ *
+ * @param predicate optional predicate to match the state against. Defaults to true.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@OrbitExperimental
+@OrbitDsl
+public suspend inline fun <S : Any, reified T : S> Flow<S>.awaitRunOn(
+    crossinline predicate: (T) -> Boolean = { true },
+    crossinline block: suspend (capturedState: T) -> Unit
+) {
+    this.dropWhile { it !is T || !predicate(it) }
+        .transformWhile {
+            if (it is T && predicate(it)) {
+                emit(it)
+                true
+            } else {
+                emit(null)
+                false
+            }
+        }
         .distinctUntilChangedBy { it != null }
         .mapLatest {
             if (it != null) {

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/Syntax.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/Syntax.kt
@@ -112,4 +112,31 @@ public class Syntax<S : Any, SE : Any>(public val containerContext: ContainerCon
                 SubStateSyntax(containerContext.toSubclassContainerContext<_, _, T>(predicate, it)).block()
             }
     }
+
+    /**
+     * This API is intended to simplify and add type-safety to working with sealed class states.
+     *
+     * Suspends until the state becomes the given subtype and the given [predicate] matches, then executes the given block.
+     *
+     * The block will be cancelled as soon as the state changes to a different type or the predicate does not return true.
+     * Note that this does not guarantee the operation in the block is atomic.
+     *
+     * The state is captured and does not change within this block.
+     *
+     * Unlike [runOn], this function does not complete immediately if the current state does not match.
+     * Instead, it suspends until the state becomes the given subtype.
+     *
+     * @param predicate optional predicate to match the state against. Defaults to true.
+     */
+    @OrbitExperimental
+    @OrbitDsl
+    public suspend inline fun <reified T : S> awaitRunOn(
+        crossinline predicate: (T) -> Boolean = { true },
+        crossinline block: suspend SubStateSyntax<S, SE, T>.() -> Unit
+    ) {
+        containerContext.stateFlow
+            .awaitRunOn<S, T>(predicate) {
+                SubStateSyntax(containerContext.toSubclassContainerContext<_, _, T>(predicate, it)).block()
+            }
+    }
 }

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RunOnTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RunOnTest.kt
@@ -166,6 +166,24 @@ internal class RunOnTest {
         }
     }
 
+    @Test
+    fun await_run_on_suspends_until_state_matches() = runTest {
+        val middleware = Middleware(backgroundScope)
+
+        middleware.testWithInternalState(this, settings = TestSettings(autoCheckInitialState = false)) {
+            expectInternalState { TestState.Loading }
+
+            val job = middleware.awaitDoIfInReadyState()
+
+            middleware.changeToState(TestState.Ready(42))
+            expectInternalState { TestState.Ready(42) }
+            expectInternalState { TestState.Ready(43) }
+
+            job.join()
+            expectNoItems()
+        }
+    }
+
     sealed interface TestState {
         object Loading : TestState
         data class Ready(val id: Int = 42) : TestState
@@ -194,6 +212,21 @@ internal class RunOnTest {
 
         fun collectIfInReadyState(predicate: (TestState.Ready) -> Boolean = { true }) = intent {
             runOn<TestState.Ready>(predicate = predicate) {
+                channel.consumeAsFlow()
+                    .collect(collectorChannel::send)
+            }
+        }
+
+        fun awaitDoIfInReadyState(predicate: (TestState.Ready) -> Boolean = { true }) = intent {
+            awaitRunOn<TestState.Ready>(predicate = predicate) {
+                reduce {
+                    state.copy(id = state.id + 1)
+                }
+            }
+        }
+
+        fun awaitCollectIfInReadyState(predicate: (TestState.Ready) -> Boolean = { true }) = intent {
+            awaitRunOn<TestState.Ready>(predicate = predicate) {
                 channel.consumeAsFlow()
                     .collect(collectorChannel::send)
             }

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RunOnTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/RunOnTest.kt
@@ -184,6 +184,86 @@ internal class RunOnTest {
         }
     }
 
+    @Test
+    fun await_run_on_runs_immediately_when_state_already_matches() = runTest {
+        val middleware = Middleware(backgroundScope)
+
+        middleware.testWithInternalState(this, settings = TestSettings(autoCheckInitialState = false)) {
+            expectInternalState { TestState.Loading }
+
+            middleware.changeToState(TestState.Ready(42))
+            expectInternalState { TestState.Ready(42) }
+
+            middleware.awaitDoIfInReadyState()
+            expectInternalState { TestState.Ready(43) }
+        }
+    }
+
+    @Test
+    fun await_run_on_respects_predicate() = runTest {
+        val middleware = Middleware(backgroundScope)
+
+        middleware.testWithInternalState(this, settings = TestSettings(autoCheckInitialState = false)) {
+            expectInternalState { TestState.Loading }
+
+            middleware.changeToState(TestState.Ready(43))
+            expectInternalState { TestState.Ready(43) }
+
+            val job = middleware.awaitDoIfInReadyState(predicate = { it.id % 2 == 0 })
+
+            middleware.changeToState(TestState.Ready(42))
+            expectInternalState { TestState.Ready(42) }
+            expectInternalState { TestState.Ready(43) }
+
+            job.join()
+            expectNoItems()
+        }
+    }
+
+    @Test
+    fun await_run_on_cancels_when_state_leaves() = runTest {
+        val middleware = Middleware(backgroundScope)
+
+        middleware.testWithInternalState(this, settings = TestSettings(autoCheckInitialState = false)) {
+            expectInternalState { TestState.Loading }
+
+            val job = middleware.awaitCollectIfInReadyState()
+
+            middleware.changeToState(TestState.Ready(42))
+            expectInternalState { TestState.Ready(42) }
+
+            middleware.channel.send(123)
+            assertEquals(123, middleware.collectorChannel.receive())
+
+            middleware.changeToState(TestState.Loading)
+            expectInternalState { TestState.Loading }
+
+            job.join()
+        }
+    }
+
+    @Test
+    fun await_run_on_cancels_when_predicate_stops_matching() = runTest {
+        val middleware = Middleware(backgroundScope)
+
+        middleware.testWithInternalState(this, settings = TestSettings(autoCheckInitialState = false)) {
+            expectInternalState { TestState.Loading }
+
+            val job = middleware.awaitCollectIfInReadyState(predicate = { it.id % 2 == 0 })
+
+            middleware.changeToState(TestState.Ready(42))
+            expectInternalState { TestState.Ready(42) }
+
+            middleware.channel.send(123)
+            assertEquals(123, middleware.collectorChannel.receive())
+
+            middleware.changeToState(TestState.Ready(43))
+            expectInternalState { TestState.Ready(43) }
+
+            job.join()
+        }
+    }
+
     sealed interface TestState {
         object Loading : TestState
         data class Ready(val id: Int = 42) : TestState

--- a/samples/orbit-text/src/main/kotlin/org/orbitmvi/orbit/sample/text/app/AwaitRunOnViewModel.kt
+++ b/samples/orbit-text/src/main/kotlin/org/orbitmvi/orbit/sample/text/app/AwaitRunOnViewModel.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit.sample.text.app
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.OrbitContainer
+import org.orbitmvi.orbit.OrbitContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
+import org.orbitmvi.orbit.orbitContainer
+
+/**
+ * Demonstrates [awaitRunOn] with a sealed class state.
+ *
+ * The container starts in [UiState.Loading] and transitions to [UiState.Ready] after a simulated
+ * delay. The [awaitRunOn] call in onCreate suspends until the state becomes [UiState.Ready], then
+ * begins observing the TextField for validation — without manual flags or stateFlow filtering.
+ */
+@Suppress("MagicNumber")
+class AwaitRunOnViewModel : OrbitContainerHost<AwaitRunOnViewModel.UiState, AwaitRunOnViewModel.UiState, Nothing> {
+    private val scope = CoroutineScope(Dispatchers.Main)
+
+    @OptIn(OrbitExperimental::class)
+    override val container: OrbitContainer<UiState, UiState, Nothing> = scope.orbitContainer(UiState.Loading) {
+        coroutineScope {
+            // Simulate loading data before the form is ready
+            launch {
+                delay(2000)
+                reduce { UiState.Ready() }
+            }
+
+            // awaitRunOn suspends here until state becomes Ready, then starts validation.
+            // No manual flags or stateFlow filtering needed.
+            launch {
+                awaitRunOn<UiState.Ready> {
+                    snapshotFlow { state.textFieldState.text }.collectLatest { text ->
+                        reduce { state.copy(validationError = text.validate()) }
+                    }
+                }
+            }
+        }
+    }
+
+    sealed interface UiState {
+        data object Loading : UiState
+
+        data class Ready(
+            val textFieldState: TextFieldState = TextFieldState(""),
+            val validationError: String? = null,
+        ) : UiState
+    }
+
+    companion object {
+        private fun CharSequence.validate(): String? = when {
+            isBlank() -> "Must not be blank"
+            length > 10 -> "Must be 10 characters or fewer"
+            else -> null
+        }
+    }
+}

--- a/samples/orbit-text/src/main/kotlin/org/orbitmvi/orbit/sample/text/app/MainActivity.kt
+++ b/samples/orbit-text/src/main/kotlin/org/orbitmvi/orbit/sample/text/app/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -42,6 +43,7 @@ import org.orbitmvi.orbit.compose.collectAsState
 class MainActivity : AppCompatActivity() {
 
     private val viewModel = TextViewModel()
+    private val awaitRunOnViewModel = AwaitRunOnViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -90,6 +92,30 @@ class MainActivity : AppCompatActivity() {
 
                     Button(onClick = { viewModel.submit() }) { Text("Submit") }
                     Text(state.result)
+
+                    Box(
+                        modifier = Modifier
+                            .padding(vertical = 16.dp)
+                            .fillMaxWidth()
+                            .height(1.dp)
+                            .background(Color.Gray)
+                    )
+
+                    Text("Demonstration of awaitRunOn with sealed class state; validation starts after loading.")
+                    val awaitState by awaitRunOnViewModel.collectAsState()
+                    when (val s = awaitState) {
+                        is AwaitRunOnViewModel.UiState.Loading -> {
+                            CircularProgressIndicator(modifier = Modifier.padding(top = 8.dp))
+                        }
+                        is AwaitRunOnViewModel.UiState.Ready -> {
+                            TextField(
+                                label = { Text(if (s.validationError != null) "awaitRunOn: ${s.validationError}" else "awaitRunOn") },
+                                state = s.textFieldState,
+                                isError = s.validationError != null,
+                                modifier = Modifier.padding(top = 8.dp)
+                            )
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

Closes #302

- Adds `awaitRunOn<T>` — a variant of `runOn<T>` that suspends until the state becomes the target sealed class subtype before executing the block
- Identical to `runOn` once the state matches: block runs with `SubStateSyntax` receiver and cancels when state leaves T or predicate stops matching
- Implementation prepends `dropWhile` to the existing `runOn` flow pipeline

### Before (workaround from #302)
```kotlin
var launched = false
init {
    container.stateFlow
        .filter { !launched && it is MyUiState.Ready }
        .onEach { launched = true; observeInputText() }
        .launchIn(container.scope)
}
```

### After
```kotlin
override val container = scope.orbitContainer<ChatUiState, Nothing>(ChatUiState.Loading) {
    coroutineScope {
        launch {
            awaitRunOn<ChatUiState.Ready> {
                repeatOnSubscription {
                    snapshotFlow { state.inputTextField.text }
                        .distinctUntilChanged()
                        .collect { inputText ->
                            reduce {
                                state.copy(inputTextValidationError = validateInputText(inputText.toString()))
                            }
                        }
                }
            }
        }
    }
}
```

## Test plan
- [x] `await_run_on_suspends_until_state_matches` — suspends while in Loading, runs when state becomes Ready
- [x] `await_run_on_runs_immediately_when_state_already_matches` — behaves like runOn when state is already Ready
- [x] `await_run_on_respects_predicate` — skips Ready states that don't match predicate, runs when one does
- [x] `await_run_on_cancels_when_state_leaves` — cancels block when state transitions away from Ready
- [x] `await_run_on_cancels_when_predicate_stops_matching` — cancels block when predicate stops matching
- [x] Full `orbit-core:jvmTest` and `orbit-test:jvmTest` suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)