### PR TITLE
docs: add caution about suspend functions in reduce block

### DIFF
--- a/website/docs/Core/index.md
+++ b/website/docs/Core/index.md
@@ -403,6 +403,28 @@ not to change.
 
 :::
 
+:::caution
+
+The `reduce` block does not support calling `suspend` functions. Since `reduce`
+is designed to be a pure, synchronous state transformation, all asynchronous
+work (e.g. API calls, database queries) must be performed **before** the
+`reduce` block.
+
+```kotlin
+// ✅ Correct - suspend call before reduce
+fun loadData() = intent {
+    val result = apiCall() // suspend call here
+    reduce { state.copy(data = result) }
+}
+
+// ❌ Wrong - suspend call inside reduce (compilation error)
+fun loadData() = intent {
+    reduce { state.copy(data = apiCall()) } // will not compile
+}
+```
+
+:::
+
 ## OrbitContainer factories
 
 ```kotlin


### PR DESCRIPTION
## Summary
Added a caution note in the Core documentation about `reduce` block 
not supporting `suspend` function calls.
This is a common mistake when first using Orbit - calling suspend functions 
(like API calls or database queries) directly inside `reduce` causes a 
compilation error. The added note includes correct/incorrect code examples.
## Motivation
While using Orbit MVI in a production Android app, I encountered this issue 
and noticed the documentation doesn't mention this restriction explicitly.