### PR TITLE
Trigger onCreate when subscribing to external state flows

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
@@ -39,6 +39,8 @@ public class LazyCreateContainerDecorator<INTERNAL_STATE : Any, EXTERNAL_STATE :
 
     override val stateFlow: StateFlow<INTERNAL_STATE> = actual.stateFlow.onSubscribe { runOnCreate() }
     override val refCountStateFlow: StateFlow<INTERNAL_STATE> = actual.refCountStateFlow.onSubscribe { runOnCreate() }
+    override val externalStateFlow: StateFlow<EXTERNAL_STATE> = actual.externalStateFlow.onSubscribe { runOnCreate() }
+    override val externalRefCountStateFlow: StateFlow<EXTERNAL_STATE> = actual.externalRefCountStateFlow.onSubscribe { runOnCreate() }
     override val sideEffectFlow: Flow<SIDE_EFFECT> = flow {
         runOnCreate()
         emitAll(actual.sideEffectFlow)

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/LazyCreateContainerDecorator.kt
@@ -40,7 +40,8 @@ public class LazyCreateContainerDecorator<INTERNAL_STATE : Any, EXTERNAL_STATE :
     override val stateFlow: StateFlow<INTERNAL_STATE> = actual.stateFlow.onSubscribe { runOnCreate() }
     override val refCountStateFlow: StateFlow<INTERNAL_STATE> = actual.refCountStateFlow.onSubscribe { runOnCreate() }
     override val externalStateFlow: StateFlow<EXTERNAL_STATE> = actual.externalStateFlow.onSubscribe { runOnCreate() }
-    override val externalRefCountStateFlow: StateFlow<EXTERNAL_STATE> = actual.externalRefCountStateFlow.onSubscribe { runOnCreate() }
+    override val externalRefCountStateFlow: StateFlow<EXTERNAL_STATE> =
+        actual.externalRefCountStateFlow.onSubscribe { runOnCreate() }
     override val sideEffectFlow: Flow<SIDE_EFFECT> = flow {
         runOnCreate()
         emitAll(actual.sideEffectFlow)

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerLifecycleTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerLifecycleTest.kt
@@ -43,12 +43,49 @@ internal class ContainerLifecycleTest {
         }
     }
 
+    @Test
+    fun on_create_is_called_when_subscribing_to_external_state_flow() = runTest {
+        val initialState = TestState()
+        val middleware = ExternalStateMiddleware(this, initialState)
+        middleware.container.externalStateFlow.test {
+            assertEquals(ExternalState(initialState.id.toString()), awaitItem())
+            assertEquals(ExternalState(ON_CREATE_ID.toString()), awaitItem())
+        }
+    }
+
+    @Test
+    fun on_create_is_called_when_subscribing_to_external_ref_count_state_flow() = runTest {
+        val initialState = TestState()
+        val middleware = ExternalStateMiddleware(this, initialState)
+        middleware.container.externalRefCountStateFlow.test {
+            assertEquals(ExternalState(initialState.id.toString()), awaitItem())
+            assertEquals(ExternalState(ON_CREATE_ID.toString()), awaitItem())
+        }
+    }
+
     private data class TestState(val id: Int = Random.nextInt())
+
+    private data class ExternalState(val id: String)
 
     private inner class Middleware(scope: TestScope, initialState: TestState) : OrbitContainerHost<TestState, TestState, String> {
 
         override val container = scope.backgroundScope.orbitContainer(initialState) {
             postSideEffect(state.id.toString())
         }
+    }
+
+    private inner class ExternalStateMiddleware(scope: TestScope, initialState: TestState) :
+        OrbitContainerHost<TestState, ExternalState, String> {
+
+        override val container = scope.backgroundScope.orbitContainer<TestState, ExternalState, String>(
+            initialState = initialState,
+            transformState = { ExternalState(it.id.toString()) }
+        ) {
+            reduce { state.copy(id = ON_CREATE_ID) }
+        }
+    }
+
+    private companion object {
+        private const val ON_CREATE_ID = -1
     }
 }


### PR DESCRIPTION
## Why

`LazyCreateContainerDecorator` runs the `onCreate` lambda lazily on the first subscription to any of its flows, but it only wrapped the internal state and side-effect flows. The external state flows (`externalStateFlow`/`externalRefCountStateFlow`) delegated straight to the wrapped container, which derives them from the raw `stateFlow`, so subscribing to them never triggered `onCreate`. This is the exact path UI consumers use (`collectAsState()` / `observe()` both subscribe to `externalRefCountStateFlow`), meaning a container exposing external state could silently skip its `onCreate` block.

## What

Override `externalStateFlow` and `externalRefCountStateFlow` in `LazyCreateContainerDecorator` with the same `onSubscribe { runOnCreate() }` wrapping used for the internal flows. Added two `ContainerLifecycleTest` cases covering subscription to each external flow.

## Testing

The new tests fail (turbine timeout waiting for the post-`onCreate` emission) against the unmodified decorator and pass after the fix; the full `orbit-core` and `orbit-test` suites pass with no regressions.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
