### PR TITLE
Add global default container settings

### DIFF
--- a/orbit-core/abi/validation/orbit-core.api
+++ b/orbit-core/abi/validation/orbit-core.api
@@ -18,6 +18,13 @@ public final class org/orbitmvi/orbit/CoroutineScopeExtensionsKt {
 	public static synthetic fun orbitContainer$default (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lorg/orbitmvi/orbit/OrbitContainer;
 }
 
+public final class org/orbitmvi/orbit/Orbit {
+	public static final field INSTANCE Lorg/orbitmvi/orbit/Orbit;
+	public final fun configureDefaults (Lkotlin/jvm/functions/Function1;)V
+	public final fun getDefaultSettings ()Lorg/orbitmvi/orbit/RealSettings;
+	public final fun resetDefaults ()V
+}
+
 public abstract interface class org/orbitmvi/orbit/OrbitContainer {
 	public abstract fun cancel ()V
 	public abstract fun getExternalRefCountStateFlow ()Lkotlinx/coroutines/flow/StateFlow;
@@ -105,14 +112,18 @@ public final class org/orbitmvi/orbit/RealSettings {
 
 public final class org/orbitmvi/orbit/SettingsBuilder {
 	public fun <init> ()V
+	public final fun getEventLoopDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getExceptionHandler ()Lkotlinx/coroutines/CoroutineExceptionHandler;
 	public final fun getIdlingRegistry ()Lorg/orbitmvi/orbit/idling/IdlingResource;
+	public final fun getIntentLaunchingDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public final fun getRepeatOnSubscribedStopTimeout ()J
 	public final fun getSideEffectBufferSize ()I
 	public final fun getSideEffectMode ()Lorg/orbitmvi/orbit/SideEffectMode;
 	public final fun getSideEffectReplayClearDelayMs ()J
+	public final fun setEventLoopDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public final fun setExceptionHandler (Lkotlinx/coroutines/CoroutineExceptionHandler;)V
 	public final fun setIdlingRegistry (Lorg/orbitmvi/orbit/idling/IdlingResource;)V
+	public final fun setIntentLaunchingDispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)V
 	public final fun setRepeatOnSubscribedStopTimeout (J)V
 	public final fun setSideEffectBufferSize (I)V
 	public final fun setSideEffectMode (Lorg/orbitmvi/orbit/SideEffectMode;)V

--- a/orbit-core/abi/validation/orbit-core.klib.api
+++ b/orbit-core/abi/validation/orbit-core.klib.api
@@ -183,12 +183,18 @@ final class org.orbitmvi.orbit/RealSettings { // org.orbitmvi.orbit/RealSettings
 final class org.orbitmvi.orbit/SettingsBuilder { // org.orbitmvi.orbit/SettingsBuilder|null[0]
     constructor <init>() // org.orbitmvi.orbit/SettingsBuilder.<init>|<init>(){}[0]
 
+    final var eventLoopDispatcher // org.orbitmvi.orbit/SettingsBuilder.eventLoopDispatcher|{}eventLoopDispatcher[0]
+        final fun <get-eventLoopDispatcher>(): kotlinx.coroutines/CoroutineDispatcher // org.orbitmvi.orbit/SettingsBuilder.eventLoopDispatcher.<get-eventLoopDispatcher>|<get-eventLoopDispatcher>(){}[0]
+        final fun <set-eventLoopDispatcher>(kotlinx.coroutines/CoroutineDispatcher) // org.orbitmvi.orbit/SettingsBuilder.eventLoopDispatcher.<set-eventLoopDispatcher>|<set-eventLoopDispatcher>(kotlinx.coroutines.CoroutineDispatcher){}[0]
     final var exceptionHandler // org.orbitmvi.orbit/SettingsBuilder.exceptionHandler|{}exceptionHandler[0]
         final fun <get-exceptionHandler>(): kotlinx.coroutines/CoroutineExceptionHandler? // org.orbitmvi.orbit/SettingsBuilder.exceptionHandler.<get-exceptionHandler>|<get-exceptionHandler>(){}[0]
         final fun <set-exceptionHandler>(kotlinx.coroutines/CoroutineExceptionHandler?) // org.orbitmvi.orbit/SettingsBuilder.exceptionHandler.<set-exceptionHandler>|<set-exceptionHandler>(kotlinx.coroutines.CoroutineExceptionHandler?){}[0]
     final var idlingRegistry // org.orbitmvi.orbit/SettingsBuilder.idlingRegistry|{}idlingRegistry[0]
         final fun <get-idlingRegistry>(): org.orbitmvi.orbit.idling/IdlingResource // org.orbitmvi.orbit/SettingsBuilder.idlingRegistry.<get-idlingRegistry>|<get-idlingRegistry>(){}[0]
         final fun <set-idlingRegistry>(org.orbitmvi.orbit.idling/IdlingResource) // org.orbitmvi.orbit/SettingsBuilder.idlingRegistry.<set-idlingRegistry>|<set-idlingRegistry>(org.orbitmvi.orbit.idling.IdlingResource){}[0]
+    final var intentLaunchingDispatcher // org.orbitmvi.orbit/SettingsBuilder.intentLaunchingDispatcher|{}intentLaunchingDispatcher[0]
+        final fun <get-intentLaunchingDispatcher>(): kotlinx.coroutines/CoroutineDispatcher // org.orbitmvi.orbit/SettingsBuilder.intentLaunchingDispatcher.<get-intentLaunchingDispatcher>|<get-intentLaunchingDispatcher>(){}[0]
+        final fun <set-intentLaunchingDispatcher>(kotlinx.coroutines/CoroutineDispatcher) // org.orbitmvi.orbit/SettingsBuilder.intentLaunchingDispatcher.<set-intentLaunchingDispatcher>|<set-intentLaunchingDispatcher>(kotlinx.coroutines.CoroutineDispatcher){}[0]
     final var repeatOnSubscribedStopTimeout // org.orbitmvi.orbit/SettingsBuilder.repeatOnSubscribedStopTimeout|{}repeatOnSubscribedStopTimeout[0]
         final fun <get-repeatOnSubscribedStopTimeout>(): kotlin/Long // org.orbitmvi.orbit/SettingsBuilder.repeatOnSubscribedStopTimeout.<get-repeatOnSubscribedStopTimeout>|<get-repeatOnSubscribedStopTimeout>(){}[0]
         final fun <set-repeatOnSubscribedStopTimeout>(kotlin/Long) // org.orbitmvi.orbit/SettingsBuilder.repeatOnSubscribedStopTimeout.<set-repeatOnSubscribedStopTimeout>|<set-repeatOnSubscribedStopTimeout>(kotlin.Long){}[0]
@@ -201,6 +207,14 @@ final class org.orbitmvi.orbit/SettingsBuilder { // org.orbitmvi.orbit/SettingsB
     final var sideEffectReplayClearDelayMs // org.orbitmvi.orbit/SettingsBuilder.sideEffectReplayClearDelayMs|{}sideEffectReplayClearDelayMs[0]
         final fun <get-sideEffectReplayClearDelayMs>(): kotlin/Long // org.orbitmvi.orbit/SettingsBuilder.sideEffectReplayClearDelayMs.<get-sideEffectReplayClearDelayMs>|<get-sideEffectReplayClearDelayMs>(){}[0]
         final fun <set-sideEffectReplayClearDelayMs>(kotlin/Long) // org.orbitmvi.orbit/SettingsBuilder.sideEffectReplayClearDelayMs.<set-sideEffectReplayClearDelayMs>|<set-sideEffectReplayClearDelayMs>(kotlin.Long){}[0]
+}
+
+final object org.orbitmvi.orbit/Orbit { // org.orbitmvi.orbit/Orbit|null[0]
+    final var defaultSettings // org.orbitmvi.orbit/Orbit.defaultSettings|{}defaultSettings[0]
+        final fun <get-defaultSettings>(): org.orbitmvi.orbit/RealSettings // org.orbitmvi.orbit/Orbit.defaultSettings.<get-defaultSettings>|<get-defaultSettings>(){}[0]
+
+    final fun configureDefaults(kotlin/Function1<org.orbitmvi.orbit/SettingsBuilder, kotlin/Unit>) // org.orbitmvi.orbit/Orbit.configureDefaults|configureDefaults(kotlin.Function1<org.orbitmvi.orbit.SettingsBuilder,kotlin.Unit>){}[0]
+    final fun resetDefaults() // org.orbitmvi.orbit/Orbit.resetDefaults|resetDefaults(){}[0]
 }
 
 final fun <#A: kotlin/Any, #B: kotlin/Any, #C: kotlin/Any> (kotlinx.coroutines/CoroutineScope).org.orbitmvi.orbit/container(#A, kotlin/Function1<#A, #B>, kotlin/Function1<org.orbitmvi.orbit/SettingsBuilder, kotlin/Unit> = ..., kotlin.coroutines/SuspendFunction1<org.orbitmvi.orbit.syntax/Syntax<#A, #C>, kotlin/Unit>? = ...): org.orbitmvi.orbit/OrbitContainer<#A, #B, #C> // org.orbitmvi.orbit/container|container@kotlinx.coroutines.CoroutineScope(0:0;kotlin.Function1<0:0,0:1>;kotlin.Function1<org.orbitmvi.orbit.SettingsBuilder,kotlin.Unit>;kotlin.coroutines.SuspendFunction1<org.orbitmvi.orbit.syntax.Syntax<0:0,0:2>,kotlin.Unit>?){0§<kotlin.Any>;1§<kotlin.Any>;2§<kotlin.Any>}[0]

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Orbit.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/Orbit.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.orbitmvi.orbit
+
+import kotlin.concurrent.Volatile
+
+/**
+ * Global Orbit configuration.
+ */
+public object Orbit {
+    /**
+     * The global default settings every new container inherits, before any per-container
+     * [SettingsBuilder] overrides are applied. Defaults to the library defaults ([RealSettings]).
+     */
+    @Volatile
+    public var defaultSettings: RealSettings = RealSettings()
+        private set
+
+    /**
+     * Configure the global default container settings. Apply once at app startup, before any
+     * containers are created. Always starts from the library defaults, so repeated calls are
+     * idempotent (not cumulative).
+     */
+    public fun configureDefaults(buildSettings: SettingsBuilder.() -> Unit) {
+        defaultSettings = SettingsBuilder(RealSettings()).apply(buildSettings).settings
+    }
+
+    /** Reset global defaults back to library defaults. Mainly for tests. */
+    public fun resetDefaults() {
+        defaultSettings = RealSettings()
+    }
+}

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/RealSettings.kt
@@ -60,14 +60,28 @@ public data class RealSettings(
     public val sideEffectReplayClearDelayMs: Long = 100L,
 )
 
-public class SettingsBuilder {
-    internal var settings = RealSettings()
+public class SettingsBuilder internal constructor(baseline: RealSettings) {
+    public constructor() : this(Orbit.defaultSettings)
+
+    internal var settings = baseline
         private set
 
     public var idlingRegistry: IdlingResource
         get() = settings.idlingRegistry
         public set(value) {
             settings = settings.copy(idlingRegistry = value)
+        }
+
+    public var eventLoopDispatcher: CoroutineDispatcher
+        get() = settings.eventLoopDispatcher
+        public set(value) {
+            settings = settings.copy(eventLoopDispatcher = value)
+        }
+
+    public var intentLaunchingDispatcher: CoroutineDispatcher
+        get() = settings.intentLaunchingDispatcher
+        public set(value) {
+            settings = settings.copy(intentLaunchingDispatcher = value)
         }
 
     public var exceptionHandler: CoroutineExceptionHandler?

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/OrbitDefaultsTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/OrbitDefaultsTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OrbitDefaultsTest {
+
+    @BeforeTest
+    fun resetBefore() {
+        Orbit.resetDefaults()
+    }
+
+    @AfterTest
+    fun resetAfter() {
+        Orbit.resetDefaults()
+    }
+
+    @Test
+    fun `configureDefaults changes settings of subsequently created containers`() = runTest {
+        Orbit.configureDefaults {
+            sideEffectMode = SideEffectMode.FAN_OUT
+            eventLoopDispatcher = Dispatchers.Unconfined
+        }
+
+        val container = backgroundScope.orbitContainer<Unit, Nothing>(Unit)
+
+        assertEquals(SideEffectMode.FAN_OUT, container.settings.sideEffectMode)
+        assertEquals(Dispatchers.Unconfined, container.settings.eventLoopDispatcher)
+    }
+
+    @Test
+    fun `per-container buildSettings overrides global default`() = runTest {
+        Orbit.configureDefaults {
+            sideEffectMode = SideEffectMode.FAN_OUT
+        }
+
+        val container = backgroundScope.orbitContainer<Unit, Nothing>(
+            initialState = Unit,
+            buildSettings = { sideEffectMode = SideEffectMode.BROADCAST }
+        )
+
+        assertEquals(SideEffectMode.BROADCAST, container.settings.sideEffectMode)
+    }
+
+    @Test
+    fun `configureDefaults is idempotent and not cumulative`() = runTest {
+        Orbit.configureDefaults {
+            sideEffectMode = SideEffectMode.FAN_OUT
+        }
+        // A second call should start from library defaults, not accumulate the first call's changes.
+        Orbit.configureDefaults {
+            repeatOnSubscribedStopTimeout = 500L
+        }
+
+        val defaults = RealSettings()
+        assertEquals(defaults.sideEffectMode, Orbit.defaultSettings.sideEffectMode)
+        assertEquals(500L, Orbit.defaultSettings.repeatOnSubscribedStopTimeout)
+    }
+
+    @Test
+    fun `resetDefaults restores library defaults`() = runTest {
+        Orbit.configureDefaults {
+            sideEffectMode = SideEffectMode.FAN_OUT
+        }
+
+        Orbit.resetDefaults()
+
+        assertEquals(RealSettings().sideEffectMode, Orbit.defaultSettings.sideEffectMode)
+    }
+
+    @Test
+    fun `SettingsBuilder dispatcher properties round-trip into RealSettings`() {
+        val settings = SettingsBuilder().apply {
+            eventLoopDispatcher = Dispatchers.Unconfined
+            intentLaunchingDispatcher = Dispatchers.Default
+        }.settings
+
+        assertEquals(Dispatchers.Unconfined, settings.eventLoopDispatcher)
+        assertEquals(Dispatchers.Default, settings.intentLaunchingDispatcher)
+    }
+}

--- a/website/docs/Core/index.md
+++ b/website/docs/Core/index.md
@@ -486,6 +486,39 @@ Extra
 factory functionality is provided via extension functions. One example is
 `ViewModel` saved state support via a `SavedStateHandle`.
 
+## Global default settings
+
+Every container's settings start from the Orbit library defaults and can be
+overridden per-container via the `buildSettings { }` block. If you want a
+particular setting (for example a `sideEffectMode` or a dispatcher) to apply
+across your whole app without repeating it at every call site, configure the
+global defaults once:
+
+```kotlin
+Orbit.configureDefaults {
+    sideEffectMode = SideEffectMode.FAN_OUT
+    intentLaunchingDispatcher = Dispatchers.Default
+}
+```
+
+Settings are layered as:
+
+1. Orbit library defaults
+2. `Orbit.configureDefaults { }` global overrides
+3. per-container `buildSettings { }` overrides (always win)
+
+`Orbit.configureDefaults` should be called **once at app startup, before any
+containers are created**. The global default is held in a single `@Volatile`
+field with no further synchronization, so configuring it after containers exist
+leads to undefined behaviour. Each call starts from the library defaults, so
+repeated calls are idempotent rather than cumulative. `Orbit.resetDefaults()`
+restores the library defaults and is mainly useful in tests.
+
+:::note
+Containers created through `orbit-test`'s `test()` helper deliberately ignore
+the global defaults to keep tests deterministic.
+:::
+
 ## Threading
 
 Orbit is designed to provide a sane default threading model to cater for most of


### PR DESCRIPTION
## What

Adds an API to set Orbit container settings **globally**, so apps can configure defaults once instead of repeating `buildSettings { }` at every call site.

- New `Orbit.configureDefaults { }` (and `Orbit.resetDefaults()`) backed by a `@Volatile` global default. Settings now layer as: library defaults → global defaults → per-container `buildSettings { }` overrides.
- `SettingsBuilder()` now seeds from the global default, and gains the previously-missing `eventLoopDispatcher` / `intentLaunchingDispatcher` properties (also usable per-container).
- `orbit-test`'s `test()` deliberately keeps ignoring global defaults to stay deterministic.
- Includes docs (Core guide), new common tests, and the regenerated `.api` / `.klib.api` binary-compat dumps.

## Why

Teams that want a setting (e.g. `SideEffectMode.FAN_OUT` or a specific dispatcher) applied app-wide currently have to repeat it everywhere; this provides a single set-once-at-startup configuration point.

## Testing

New `OrbitDefaultsTest` covers propagation, per-container override precedence, idempotency, reset, and dispatcher round-trip; `:orbit-core:apiCheck` and the full `:orbit-core:jvmTest` suite pass.