### PR TITLE
Document awaitRunOn and stabilise runOn/subIntent

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHost.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/ContainerHost.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.annotation.OrbitDsl
-import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.syntax.Syntax
 import org.orbitmvi.orbit.syntax.intent
 
@@ -85,14 +84,12 @@ public interface OrbitContainerHost<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, 
      *             }
      *         }
      *
-     * @OptIn(OrbitExperimental::class)
      * private suspend fun sendSideEffect1() = subIntent {
      *     flow1.collect {
      *         postSideEffect(it)
      *     }
      * }
      *
-     * @OptIn(OrbitExperimental::class)
      * private suspend fun sendSideEffect1() = subIntent {
      *     flow2.collect {
      *         postSideEffect(it)
@@ -104,7 +101,6 @@ public interface OrbitContainerHost<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, 
      * @param transformer lambda representing the transformer
      */
     @OrbitDsl
-    @OrbitExperimental
     public suspend fun subIntent(
         transformer: suspend Syntax<INTERNAL_STATE, SIDE_EFFECT>.() -> Unit,
     ): Unit = container.inlineOrbit {

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/RunOn.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/RunOn.kt
@@ -43,7 +43,6 @@ import org.orbitmvi.orbit.annotation.OrbitInternal
  * @param predicate optional predicate to match the state against. Defaults to true.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-@OrbitExperimental
 @OrbitDsl
 public suspend inline fun <S : Any, reified T : S> Flow<S>.runOn(
     crossinline predicate: (T) -> Boolean = { true },

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/Syntax.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/syntax/Syntax.kt
@@ -101,7 +101,6 @@ public class Syntax<S : Any, SE : Any>(public val containerContext: ContainerCon
      *
      * @param predicate optional predicate to match the state against. Defaults to true.
      */
-    @OrbitExperimental
     @OrbitDsl
     public suspend inline fun <reified T : S> runOn(
         crossinline predicate: (T) -> Boolean = { true },

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/ContainerHostWithExternalStateTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/ContainerHostWithExternalStateTest.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.test.runTest
-import org.orbitmvi.orbit.annotation.OrbitExperimental
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -127,7 +126,6 @@ class ContainerHostWithExternalStateTest {
 
         fun newSideEffect(action: Int) = intent { postSideEffect(action) }
 
-        @OptIn(OrbitExperimental::class)
         private suspend fun subIntent(action: Int) = subIntent { reduce { action } }
 
         private fun transformState(internalState: Int): String {

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SubIntentTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/SubIntentTest.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.orbitmvi.orbit.OrbitContainerHost
-import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.orbitContainer
 import org.orbitmvi.orbit.test.testWithInternalState
 import kotlin.random.Random
@@ -81,14 +80,12 @@ internal class SubIntentTest {
             }
         }
 
-        @OptIn(OrbitExperimental::class)
         private suspend fun sendSideEffect1() = subIntent {
             flow1.collect {
                 postSideEffect(it)
             }
         }
 
-        @OptIn(OrbitExperimental::class)
         private suspend fun sendSideEffect2() = subIntent {
             flow2.collect {
                 postSideEffect(it)

--- a/samples/orbit-posts-compose-multiplatform/composeApp/src/commonMain/kotlin/org/orbitmvi/orbit/sample/posts/compose/multiplatform/domain/viewmodel/detail/PostDetailsViewModel.kt
+++ b/samples/orbit-posts-compose-multiplatform/composeApp/src/commonMain/kotlin/org/orbitmvi/orbit/sample/posts/compose/multiplatform/domain/viewmodel/detail/PostDetailsViewModel.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.Job
 import org.orbitmvi.orbit.OrbitContainer
 import org.orbitmvi.orbit.OrbitContainerHost
-import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.sample.posts.compose.multiplatform.domain.repositories.PostOverview
 import org.orbitmvi.orbit.sample.posts.compose.multiplatform.domain.repositories.PostRepository
 import org.orbitmvi.orbit.viewmodel.orbitContainer
@@ -41,7 +40,6 @@ public class PostDetailsViewModel(
             }
         }
 
-    @OptIn(OrbitExperimental::class)
     private suspend fun loadDetails() = subIntent {
         runCatching {
             postRepository.getDetail(postOverview.id)

--- a/samples/orbit-posts-compose-multiplatform/composeApp/src/commonMain/kotlin/org/orbitmvi/orbit/sample/posts/compose/multiplatform/domain/viewmodel/list/PostListViewModel.kt
+++ b/samples/orbit-posts-compose-multiplatform/composeApp/src/commonMain/kotlin/org/orbitmvi/orbit/sample/posts/compose/multiplatform/domain/viewmodel/list/PostListViewModel.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.Job
 import org.orbitmvi.orbit.OrbitContainer
 import org.orbitmvi.orbit.OrbitContainerHost
-import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.sample.posts.compose.multiplatform.domain.repositories.PostOverview
 import org.orbitmvi.orbit.sample.posts.compose.multiplatform.domain.repositories.PostRepository
 import org.orbitmvi.orbit.sample.posts.compose.multiplatform.domain.viewmodel.NavigationEvent
@@ -44,7 +43,6 @@ public class PostListViewModel(
         }
     }
 
-    @OptIn(OrbitExperimental::class)
     private suspend fun loadOverviews() = subIntent {
         runCatching {
             postRepository.getOverviews()

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/viewmodel/PostDetailsViewModel.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postdetails/viewmodel/PostDetailsViewModel.kt
@@ -23,7 +23,6 @@ package org.orbitmvi.orbit.sample.posts.app.features.postdetails.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import org.orbitmvi.orbit.OrbitContainerHost
-import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.sample.posts.domain.repositories.PostOverview
 import org.orbitmvi.orbit.sample.posts.domain.repositories.PostRepository
 import org.orbitmvi.orbit.sample.posts.domain.repositories.Status
@@ -41,7 +40,6 @@ class PostDetailsViewModel(
         }
     }
 
-    @OptIn(OrbitExperimental::class)
     private suspend fun loadDetails() = subIntent {
         val status = postRepository.getDetail(postOverview.id)
 

--- a/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
+++ b/samples/orbit-posts/src/main/kotlin/org/orbitmvi/orbit/sample/posts/app/features/postlist/viewmodel/PostListViewModel.kt
@@ -23,7 +23,6 @@ package org.orbitmvi.orbit.sample.posts.app.features.postlist.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import org.orbitmvi.orbit.OrbitContainerHost
-import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.sample.posts.app.common.NavigationEvent
 import org.orbitmvi.orbit.sample.posts.domain.repositories.PostOverview
 import org.orbitmvi.orbit.sample.posts.domain.repositories.PostRepository
@@ -43,7 +42,6 @@ class PostListViewModel(
         }
     }
 
-    @OptIn(OrbitExperimental::class)
     private suspend fun loadOverviews() = subIntent {
         runCatching {
             val overviews = postRepository.getOverviews()

--- a/website/docs/Core/index.md
+++ b/website/docs/Core/index.md
@@ -163,6 +163,7 @@ they map to MVI concepts:
 | -                  | `repeatOnSubscription { ... }` | Helps collect infinite flows only when there are active subscribers                                       |
 | -                  | `subIntent { ... }`            | Use this to break big `intent` blocks into smaller parts, or for parallel decomposition.                  |
 | -                  | `runOn { ... }`                | Useful for working with sealed class states. The block is only executed if (and while) the state matches. |
+| -                  | `awaitRunOn { ... }`           | Like `runOn`, but suspends until the state matches instead of completing immediately.                     |
 
 Operators are invoked through the `intent` block in a
 [OrbitContainerHost](pathname:///dokka/orbit-core/org.orbitmvi.orbit/-orbit-container-host/).
@@ -368,7 +369,7 @@ class Example : OrbitContainerHost<ExampleSealedClassState, ExampleSealedClassSt
     }
 
      fun withRunOn() = intent {
-        runOn(ExampleSealedClassState.Ready::class) {
+        runOn<ExampleSealedClassState.Ready> {
             ... run some operations with the captured state
         }
     }
@@ -384,6 +385,42 @@ matches the provided type or predicate.
 
 Note that there are no atomicity guarantees when using `runOn`. The block may
 get executed partially.
+
+### AwaitRunOn
+
+```kotlin
+class Example : OrbitContainerHost<ExampleSealedClassState, ExampleSealedClassState, ExampleSideEffect> {
+    ...
+    
+    override val container = 
+        scope.orbitContainer<ExampleSealedClassState, ExampleSideEffect>(
+            ExampleSealedClassState.Loading
+        ) {
+            onCreate {
+                awaitRunOn<ExampleSealedClassState.Ready> {
+                    ... run some operations once the state becomes Ready
+                }
+            }
+        }
+}
+```
+
+`awaitRunOn` behaves like [runOn](#runon), with one difference: when the
+current state does not match the provided type and optional predicate, it
+suspends until it does, rather than completing immediately.
+
+This is useful when you want to start work as soon as the container reaches a
+particular state — for example, awaiting a `Ready` state in `onCreate` before
+collecting a flow.
+
+As with `runOn`, the block is automatically cancelled when the state no longer
+matches the provided type or predicate, and there are no atomicity guarantees.
+
+:::note
+
+`awaitRunOn` is experimental and requires opting in to `@OrbitExperimental`.
+
+:::
 
 ### Operator context
 


### PR DESCRIPTION
## Why

`awaitRunOn` was added in #325 but never documented on the website, and `runOn`/`subIntent` have proven themselves enough to drop their experimental status.

## What

- Documents `awaitRunOn` in the Core docs (operators table + dedicated section) and fixes the stale `KClass`-based `runOn` example — the API is a reified generic.
- Removes `@OrbitExperimental` from `runOn` and `subIntent` (`awaitRunOn` stays experimental) and cleans up the now-redundant `@OptIn` annotations in tests and samples.

## Testing

`:orbit-core:jvmTest` and `:orbit-core:apiCheck` pass locally (API dumps unaffected), and the Docusaurus site builds successfully; CI covers the remaining targets. Docs changes have no runtime surface.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)