### PR TITLE
Add docs version selector generated from release tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so generate-versions.mjs can extract docs from
+          # release tags
+          fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
@@ -33,6 +37,9 @@ jobs:
 
       - name: Build Dokka
         run: ./gradlew copyDokkaToWebsite
+
+      - name: Generate versioned docs
+        run: node website/scripts/generate-versions.mjs
 
       - name: Build Docusaurus Docker Image
         uses: docker/build-push-action@v4

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -10,6 +10,10 @@ build
 supervisord.pid
 supervisord.log
 dokka
+versions.json
+versioned_docs
+versioned_sidebars
+src/plugins/github-latest-release/generated
 
 # Misc
 .DS_Store

--- a/website/README.md
+++ b/website/README.md
@@ -3,6 +3,27 @@
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern
 static website generator.
 
+## Doc versioning
+
+Doc versions are generated from git release tags at build time — nothing is
+committed to the repository:
+
+- The site root serves the docs from the **latest release tag**, so the
+  published docs always match the latest release.
+- `/next/` serves the working `docs/` directory (docs for unreleased changes).
+- Older majors are served at `/11.x/`, `/10.x/`, etc. — one version per major,
+  taken from the latest release tag of that major.
+
+`scripts/generate-versions.mjs` produces `versions.json`, `versioned_docs/` and
+`versioned_sidebars/` (all gitignored) and is run by CI before the site build.
+Releasing works as usual: tag a commit and CI regenerates the site — a new
+major tag automatically becomes the root version. To retire a version from the
+selector, raise `MIN_MAJOR` in the script.
+
+To preview the versioned site locally, run `yarn generate-versions` (requires
+git and node on the host) before building. Without it, the working `docs/` are
+served at the root as before.
+
 ## Preparations
 
 Before running any website commands, build the bundled docusaurus dockerfile and

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -44,6 +44,14 @@ const config = {
                 docs: {
                     routeBasePath: '/',
                     sidebarPath: './sidebars.js',
+                    // Versions are generated at build time from release tags
+                    // by scripts/generate-versions.mjs; the newest generated
+                    // version is served at the site root and `docs/` (the
+                    // "current" version) at /next/. Without generated
+                    // versions, `docs/` is served at the root as before.
+                    versions: {
+                        current: {label: 'Next'},
+                    },
                 },
                 theme: {
                     customCss: './src/css/custom.css',
@@ -62,6 +70,11 @@ const config = {
                     src: 'img/orbit.svg',
                 },
                 items: [
+                    {
+                        type: 'docsVersionDropdown',
+                        position: 'right',
+                        dropdownActiveClassDisabled: true,
+                    },
                     {
                         href: 'https://github.com/orbit-mvi/orbit-mvi',
                         label: 'GitHub',

--- a/website/package.json
+++ b/website/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "generate-versions": "node scripts/generate-versions.mjs",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",

--- a/website/scripts/generate-versions.mjs
+++ b/website/scripts/generate-versions.mjs
@@ -1,0 +1,134 @@
+// Generates Docusaurus doc versions from git release tags at build time.
+//
+// For each major release version (>= MIN_MAJOR), the docs from the latest
+// release tag of that major are extracted into versioned_docs/, so the site
+// root always serves the docs matching the latest release, while the working
+// docs/ directory is published at /next/. Nothing this script produces is
+// committed — versions.json, versioned_docs/ and versioned_sidebars/ are
+// regenerated on every build (see website/.gitignore).
+//
+// Requires git (with the release tags fetched) and node; no npm dependencies.
+
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {pathToFileURL, fileURLToPath} from 'node:url';
+
+// Docs from tags below this major predate the Docusaurus 3 migration and no
+// longer compile; raise it to retire a version from the selector.
+const MIN_MAJOR = 10;
+
+const websiteDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoDir = path.resolve(websiteDir, '..');
+
+function git(...args) {
+    return execFileSync('git', args, {cwd: repoDir, encoding: 'utf-8'});
+}
+
+const releaseTags = git('tag', '--list')
+    .split('\n')
+    .filter((tag) => /^\d+\.\d+\.\d+$/.test(tag))
+    .map((tag) => ({tag, parts: tag.split('.').map(Number)}));
+
+const latestTagByMajor = new Map();
+for (const release of releaseTags) {
+    const [major] = release.parts;
+    if (major < MIN_MAJOR) {
+        continue;
+    }
+    const current = latestTagByMajor.get(major);
+    const isNewer = !current
+        || release.parts[1] > current.parts[1]
+        || (release.parts[1] === current.parts[1] && release.parts[2] > current.parts[2]);
+    if (isNewer) {
+        latestTagByMajor.set(major, release);
+    }
+}
+
+const majors = [...latestTagByMajor.keys()].sort((a, b) => b - a);
+if (majors.length === 0) {
+    console.error(`No release tags with major >= ${MIN_MAJOR} found; are tags fetched?`);
+    process.exit(1);
+}
+
+const versionedDocsDir = path.join(websiteDir, 'versioned_docs');
+const versionedSidebarsDir = path.join(websiteDir, 'versioned_sidebars');
+fs.rmSync(versionedDocsDir, {recursive: true, force: true});
+fs.rmSync(versionedSidebarsDir, {recursive: true, force: true});
+fs.mkdirSync(versionedSidebarsDir, {recursive: true});
+
+function extractDocs(tag, destination) {
+    fs.mkdirSync(destination, {recursive: true});
+    const archive = execFileSync('git', ['archive', tag, 'website/docs'], {
+        cwd: repoDir,
+        maxBuffer: 256 * 1024 * 1024,
+    });
+    execFileSync('tar', ['-x', '--strip-components=2', '-C', destination], {input: archive});
+}
+
+// The working docs' index.md renders the install snippet with the release
+// version fetched from the GitHub API at build time (the github-latest-release
+// plugin). A snapshot must not do that — it would advertise the newest release
+// in old docs — so bake the snapshot's own release version in as plain text.
+function freezeReleaseVersion(indexFile, tag) {
+    const original = fs.readFileSync(indexFile, 'utf-8');
+    const frozen = original
+        .replace(/^import CodeBlock from .*\n/m, '')
+        .replace(/^import latestRelease from .*\n/m, '')
+        .replaceAll('{latestRelease.tag_name}', tag)
+        .replace(
+            /<CodeBlock language="kotlin">([\s\S]*?)<\/CodeBlock>/,
+            (_, code) => '```kotlin\n' + code.trim() + '\n```',
+        );
+    if (frozen.includes('latestRelease') || frozen.includes('CodeBlock')) {
+        throw new Error(`Failed to freeze the release version in ${indexFile}`);
+    }
+    fs.writeFileSync(indexFile, frozen);
+}
+
+// Versioned sidebars are JSON files with the same shape as the sidebars.js
+// export, so evaluate the tag's sidebars.js and serialise it.
+async function loadSidebars(tag) {
+    const source = git('show', `${tag}:website/sidebars.js`);
+    const tempFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'orbit-sidebars-')), 'sidebars.mjs');
+    fs.writeFileSync(tempFile, source);
+    try {
+        return (await import(pathToFileURL(tempFile))).default;
+    } finally {
+        fs.rmSync(path.dirname(tempFile), {recursive: true, force: true});
+    }
+}
+
+// Dokka output is only generated for the working tree, so every version links
+// to the latest API docs; relabel the category to say so.
+function relabelDokka(sidebars) {
+    for (const item of Object.values(sidebars).flat()) {
+        if (item?.type === 'category' && item.label === 'Dokka') {
+            item.label = 'Dokka (latest)';
+        }
+    }
+}
+
+for (const major of majors) {
+    const {tag} = latestTagByMajor.get(major);
+    const label = `${major}.x`;
+    const docsDir = path.join(versionedDocsDir, `version-${label}`);
+
+    extractDocs(tag, docsDir);
+    freezeReleaseVersion(path.join(docsDir, 'index.md'), tag);
+
+    const sidebars = await loadSidebars(tag);
+    relabelDokka(sidebars);
+    fs.writeFileSync(
+        path.join(versionedSidebarsDir, `version-${label}-sidebars.json`),
+        JSON.stringify(sidebars, null, 2) + '\n',
+    );
+
+    console.log(`Generated docs version ${label} from tag ${tag}`);
+}
+
+fs.writeFileSync(
+    path.join(websiteDir, 'versions.json'),
+    JSON.stringify(majors.map((major) => `${major}.x`), null, 2) + '\n',
+);


### PR DESCRIPTION
## Why

The docs site only showed main's docs, which drift ahead of the latest release (they already describe unreleased 12.x features). This adds a navbar version dropdown and keeps the published docs in sync with the release tag.

## What

A new build-time script (`website/scripts/generate-versions.mjs`, run by the docs workflow before the site build) extracts docs from the latest release tag of each major (≥ 10, older docs predate Docusaurus 3) into gitignored `versioned_docs/`, freezing the literal release version into each snapshot's install snippet. The newest generated version is served at the site root, main's working docs move to `/next/` labelled "Next", and the release flow and website artifact upload are unchanged — a new release tag automatically becomes the root version on the next build.

## Testing

Verified with a full local build (`yarn generate-versions && yarn build`, `onBrokenLinks: 'throw'` passing): root serves the 11.0.0 tag's docs with a literal `11.0.0` install snippet, `/next/` serves main's docs with the unreleased banner, `/10.x/` is frozen at 10.0.0 with the maintenance banner, and the dropdown lists `11.x · 10.x · Next`.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)