### PR TITLE
Deploy docs site to Dreamhost from CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,12 @@ on:
       - main
       - orbit/main
       - feature/**
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'rsync --dry-run (log changes, upload nothing)'
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -52,3 +58,41 @@ jobs:
           name: website
           path: |
             website/build
+
+  deploy:
+    name: Deploy to Dreamhost
+    needs: build
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+        (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')))
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://orbit-mvi.org
+    concurrency:
+      group: docs-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Download website artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: website
+          path: website/build
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "${{ secrets.DEPLOY_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+
+      - name: Deploy via rsync
+        run: |
+          rsync -az --delete \
+            ${{ inputs.dry_run && '--dry-run --verbose' || '' }} \
+            --exclude '.well-known' \
+            --exclude '.htaccess' \
+            -e "ssh -o StrictHostKeyChecking=yes" \
+            website/build/ \
+            "${{ secrets.DEPLOY_SSH_USER }}@${{ secrets.DEPLOY_SSH_HOST }}:${{ secrets.DEPLOY_PATH }}/"


### PR DESCRIPTION
## Why

The Docusaurus workflow builds the full site but stops at uploading it as a CI artifact — getting it onto orbit-mvi.org is a manual step. This automates it so the site stays in sync with main and release tags.

## What

Adds a `deploy` job to `docs.yml` that downloads the existing `website` artifact and rsyncs it (`-az --delete`) to Dreamhost over SSH:

- Runs on pushes to `main` and release tags; never on PRs. A `workflow_dispatch` trigger allows manual redeploys, with a `dry_run` option that logs what rsync would change without uploading anything.
- Uses a `production` GitHub environment for secret scoping, deployment history, and optional protection rules.
- Host key is pinned via a `known_hosts` secret (`StrictHostKeyChecking=yes`), so a Dreamhost server migration fails loudly instead of being silently accepted.
- A `docs-deploy` concurrency group queues the near-simultaneous main+tag deploys at release time (content is identical either way).

### One-time setup required before this works

Secrets on the `production` environment (Settings → Environments):

| Secret | Value |
|---|---|
| `DEPLOY_SSH_KEY` | ed25519 private key (no passphrase), pubkey in the Dreamhost user's `~/.ssh/authorized_keys` |
| `DEPLOY_SSH_USER` | Dreamhost **shell** user (SFTP-only can't rsync) |
| `DEPLOY_SSH_HOST` | Server hostname from the Dreamhost panel |
| `DEPLOY_PATH` | e.g. `/home/<user>/orbit-mvi.org` (no trailing slash) |
| `DEPLOY_KNOWN_HOSTS` | Output of `ssh-keyscan -t ed25519 <host>` |

Note: `--delete` removes anything server-side that isn't in the build output (`.well-known`/`.htaccess` are excluded).

## Testing

PR CI runs only the `build` job, validating the workflow syntax and artifact wiring. After merge and secret setup, a `workflow_dispatch` run with `dry_run: true` verifies SSH auth and shows the exact upload/delete list before the first real deploy.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)