### PR TITLE
Fix ContainerLifecycleTest compilation after dispatcher factory change

### DIFF
--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerLifecycleTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerLifecycleTest.kt
@@ -83,7 +83,7 @@ internal class ContainerLifecycleTest {
         override val container = scope.backgroundScope.orbitContainer<TestState, ExternalState, String>(
             initialState = initialState,
             transformState = { ExternalState(it.id.toString()) },
-            buildSettings = { eventLoopDispatcher = StandardTestDispatcher(scope.testScheduler) }
+            buildSettings = { eventLoopDispatcher = { StandardTestDispatcher(scope.testScheduler) } }
         ) {
             reduce { state.copy(id = ON_CREATE_ID) }
         }


### PR DESCRIPTION
## Why

Unit tests on main fail to compile since #337 made `eventLoopDispatcher` a `() -> CoroutineDispatcher` factory — one assignment in `ContainerLifecycleTest` was missed.

## What

Wrap the `StandardTestDispatcher` assignment in a factory lambda.

## Testing

`:orbit-core:jvmTest` passes locally.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)