### PR TITLE
Add public awaitItem() to the new test contexts (#343)

### DIFF
--- a/orbit-test/abi/validation/orbit-test.api
+++ b/orbit-test/abi/validation/orbit-test.api
@@ -82,6 +82,7 @@ public abstract class org/orbitmvi/orbit/test/OrbitScopedTestContextBase {
 public final class org/orbitmvi/orbit/test/OrbitScopedTestContextExternal : org/orbitmvi/orbit/test/OrbitScopedTestContextBase {
 	public fun <init> (Lorg/orbitmvi/orbit/OrbitContainerHost;Ljava/lang/Object;Lapp/cash/turbine/ReceiveTurbine;)V
 	public final fun awaitExternalState (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun awaitItem (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun expectExternalState (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun expectExternalState (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCurrentConsumedExternalState ()Ljava/lang/Object;
@@ -91,6 +92,7 @@ public final class org/orbitmvi/orbit/test/OrbitScopedTestContextExternal : org/
 public final class org/orbitmvi/orbit/test/OrbitScopedTestContextInternal : org/orbitmvi/orbit/test/OrbitScopedTestContextBase {
 	public fun <init> (Lorg/orbitmvi/orbit/OrbitContainerHost;Ljava/lang/Object;Lapp/cash/turbine/ReceiveTurbine;)V
 	public final fun awaitInternalState (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun awaitItem (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun expectInternalState (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun expectInternalState (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCurrentConsumedInternalState ()Ljava/lang/Object;

--- a/orbit-test/abi/validation/orbit-test.api
+++ b/orbit-test/abi/validation/orbit-test.api
@@ -103,6 +103,7 @@ public final class org/orbitmvi/orbit/test/OrbitScopedTestContextInternalAndExte
 	public fun <init> (Lorg/orbitmvi/orbit/OrbitContainerHost;Ljava/lang/Object;Lapp/cash/turbine/ReceiveTurbine;)V
 	public final fun awaitExternalState (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun awaitInternalState (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun awaitItem (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun expectExternalState (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun expectExternalState (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun expectInternalState (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/orbit-test/abi/validation/orbit-test.klib.api
+++ b/orbit-test/abi/validation/orbit-test.klib.api
@@ -60,6 +60,7 @@ final class <#A: kotlin/Any, #B: kotlin/Any, #C: kotlin/Any, #D: org.orbitmvi.or
 
     final suspend fun awaitExternalState(): #B // org.orbitmvi.orbit.test/OrbitScopedTestContextInternalAndExternal.awaitExternalState|awaitExternalState(){}[0]
     final suspend fun awaitInternalState(): #A // org.orbitmvi.orbit.test/OrbitScopedTestContextInternalAndExternal.awaitInternalState|awaitInternalState(){}[0]
+    final suspend fun awaitItem(): org.orbitmvi.orbit.test/ItemWithInternalAndExternalState<#A, #B, #C> // org.orbitmvi.orbit.test/OrbitScopedTestContextInternalAndExternal.awaitItem|awaitItem(){}[0]
     final suspend fun expectExternalState(#B) // org.orbitmvi.orbit.test/OrbitScopedTestContextInternalAndExternal.expectExternalState|expectExternalState(1:1){}[0]
     final suspend fun expectExternalState(kotlin/Function1<#B, #B>) // org.orbitmvi.orbit.test/OrbitScopedTestContextInternalAndExternal.expectExternalState|expectExternalState(kotlin.Function1<1:1,1:1>){}[0]
     final suspend fun expectInternalState(#A) // org.orbitmvi.orbit.test/OrbitScopedTestContextInternalAndExternal.expectInternalState|expectInternalState(1:0){}[0]

--- a/orbit-test/abi/validation/orbit-test.klib.api
+++ b/orbit-test/abi/validation/orbit-test.klib.api
@@ -28,6 +28,7 @@ final class <#A: kotlin/Any, #B: kotlin/Any, #C: kotlin/Any, #D: org.orbitmvi.or
         final fun <set-currentConsumedExternalState>(#B) // org.orbitmvi.orbit.test/OrbitScopedTestContextExternal.currentConsumedExternalState.<set-currentConsumedExternalState>|<set-currentConsumedExternalState>(1:1){}[0]
 
     final suspend fun awaitExternalState(): #B // org.orbitmvi.orbit.test/OrbitScopedTestContextExternal.awaitExternalState|awaitExternalState(){}[0]
+    final suspend fun awaitItem(): org.orbitmvi.orbit.test/Item<#B, #C> // org.orbitmvi.orbit.test/OrbitScopedTestContextExternal.awaitItem|awaitItem(){}[0]
     final suspend fun expectExternalState(#B) // org.orbitmvi.orbit.test/OrbitScopedTestContextExternal.expectExternalState|expectExternalState(1:1){}[0]
     final suspend fun expectExternalState(kotlin/Function1<#B, #B>) // org.orbitmvi.orbit.test/OrbitScopedTestContextExternal.expectExternalState|expectExternalState(kotlin.Function1<1:1,1:1>){}[0]
     final suspend inline fun <#A1: reified #B> expectExternalStateOn(kotlin/Function1<#A1, #B>) // org.orbitmvi.orbit.test/OrbitScopedTestContextExternal.expectExternalStateOn|expectExternalStateOn(kotlin.Function1<0:0,1:1>){0§<1:1>}[0]
@@ -41,6 +42,7 @@ final class <#A: kotlin/Any, #B: kotlin/Any, #C: kotlin/Any, #D: org.orbitmvi.or
         final fun <set-currentConsumedInternalState>(#A) // org.orbitmvi.orbit.test/OrbitScopedTestContextInternal.currentConsumedInternalState.<set-currentConsumedInternalState>|<set-currentConsumedInternalState>(1:0){}[0]
 
     final suspend fun awaitInternalState(): #A // org.orbitmvi.orbit.test/OrbitScopedTestContextInternal.awaitInternalState|awaitInternalState(){}[0]
+    final suspend fun awaitItem(): org.orbitmvi.orbit.test/Item<#A, #C> // org.orbitmvi.orbit.test/OrbitScopedTestContextInternal.awaitItem|awaitItem(){}[0]
     final suspend fun expectInternalState(#A) // org.orbitmvi.orbit.test/OrbitScopedTestContextInternal.expectInternalState|expectInternalState(1:0){}[0]
     final suspend fun expectInternalState(kotlin/Function1<#A, #A>) // org.orbitmvi.orbit.test/OrbitScopedTestContextInternal.expectInternalState|expectInternalState(kotlin.Function1<1:0,1:0>){}[0]
     final suspend inline fun <#A1: reified #A> expectInternalStateOn(kotlin/Function1<#A1, #A>) // org.orbitmvi.orbit.test/OrbitScopedTestContextInternal.expectInternalStateOn|expectInternalStateOn(kotlin.Function1<0:0,1:0>){0§<1:0>}[0]

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextBase.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextBase.kt
@@ -64,7 +64,7 @@ public abstract class OrbitScopedTestContextBase<
         emissions.expectNoEvents()
     }
 
-    internal suspend fun awaitItem(): ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT> {
+    internal suspend fun awaitRawItem(): ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT> {
         return emissions.awaitItem()
     }
 
@@ -75,7 +75,7 @@ public abstract class OrbitScopedTestContextBase<
      * @throws AssertionError if the most recent item was not a side effect.
      */
     public suspend fun awaitSideEffect(): SIDE_EFFECT {
-        val item = awaitItem()
+        val item = awaitRawItem()
 
         return (item as? ItemWithInternalAndExternalState.SideEffectItem)?.value ?: fail("Expected Side Effect but got $item")
     }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextExternal.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextExternal.kt
@@ -82,8 +82,28 @@ public class OrbitScopedTestContextExternal<
      * @throws AssertionError if the most recent item was not an external state.
      */
     public suspend fun awaitExternalState(): EXTERNAL_STATE {
-        val item = awaitItem()
+        val item = awaitRawItem()
         return (item as? ItemWithInternalAndExternalState.ExternalStateItem)?.value?.also { currentConsumedExternalState = it }
             ?: fail("Expected External State but got $item")
+    }
+
+    /**
+     * Return the next item received as either an external state or a side effect.
+     * This function will suspend if no items have been received.
+     *
+     * Useful when the ordering of states and side effects is not deterministic and you need to
+     * drain items until a particular one arrives. Consuming an external state advances the state
+     * used for subsequent relative assertions (e.g. [expectExternalState]).
+     */
+    public suspend fun awaitItem(): Item<EXTERNAL_STATE, SIDE_EFFECT> {
+        return when (val item = awaitRawItem()) {
+            is ItemWithInternalAndExternalState.ExternalStateItem ->
+                Item.StateItem(item.value.also { currentConsumedExternalState = it })
+
+            is ItemWithInternalAndExternalState.SideEffectItem -> Item.SideEffectItem(item.value)
+
+            is ItemWithInternalAndExternalState.InternalStateItem ->
+                fail("Expected an external state or side effect but got $item")
+        }
     }
 }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextInternal.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextInternal.kt
@@ -79,8 +79,28 @@ public class OrbitScopedTestContextInternal<
      * @throws AssertionError if the most recent item was not an internal state.
      */
     public suspend fun awaitInternalState(): INTERNAL_STATE {
-        val item = awaitItem()
+        val item = awaitRawItem()
         return (item as? ItemWithInternalAndExternalState.InternalStateItem)?.value?.also { currentConsumedInternalState = it }
             ?: fail("Expected Internal State but got $item")
+    }
+
+    /**
+     * Return the next item received as either an internal state or a side effect.
+     * This function will suspend if no items have been received.
+     *
+     * Useful when the ordering of states and side effects is not deterministic and you need to
+     * drain items until a particular one arrives. Consuming an internal state advances the state
+     * used for subsequent relative assertions (e.g. [expectInternalState]).
+     */
+    public suspend fun awaitItem(): Item<INTERNAL_STATE, SIDE_EFFECT> {
+        return when (val item = awaitRawItem()) {
+            is ItemWithInternalAndExternalState.InternalStateItem ->
+                Item.StateItem(item.value.also { currentConsumedInternalState = it })
+
+            is ItemWithInternalAndExternalState.SideEffectItem -> Item.SideEffectItem(item.value)
+
+            is ItemWithInternalAndExternalState.ExternalStateItem ->
+                fail("Expected an internal state or side effect but got $item")
+        }
     }
 }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextInternalAndExternal.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextInternalAndExternal.kt
@@ -122,7 +122,7 @@ public class OrbitScopedTestContextInternalAndExternal<
      * @throws AssertionError if the most recent item was not an internal state.
      */
     public suspend fun awaitInternalState(): INTERNAL_STATE {
-        val item = awaitItem()
+        val item = awaitRawItem()
         return (item as? ItemWithInternalAndExternalState.InternalStateItem)?.value?.also { currentConsumedInternalState = it }
             ?: fail("Expected Internal State but got $item")
     }
@@ -134,7 +134,7 @@ public class OrbitScopedTestContextInternalAndExternal<
      * @throws AssertionError if the most recent item was not an external state.
      */
     public suspend fun awaitExternalState(): EXTERNAL_STATE {
-        val item = awaitItem()
+        val item = awaitRawItem()
         return (item as? ItemWithInternalAndExternalState.ExternalStateItem)?.value?.also { currentConsumedExternalState = it }
             ?: fail("Expected External State but got $item")
     }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextInternalAndExternal.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitScopedTestContextInternalAndExternal.kt
@@ -138,4 +138,22 @@ public class OrbitScopedTestContextInternalAndExternal<
         return (item as? ItemWithInternalAndExternalState.ExternalStateItem)?.value?.also { currentConsumedExternalState = it }
             ?: fail("Expected External State but got $item")
     }
+
+    /**
+     * Return the next item received as an internal state, external state, or side effect.
+     * This function will suspend if no items have been received.
+     *
+     * Useful when the ordering of states and side effects is not deterministic and you need to
+     * drain items until a particular one arrives. Consuming a state advances the state used for
+     * subsequent relative assertions (e.g. [expectInternalState], [expectExternalState]).
+     */
+    public suspend fun awaitItem(): ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT> {
+        return awaitRawItem().also { item ->
+            when (item) {
+                is ItemWithInternalAndExternalState.InternalStateItem -> currentConsumedInternalState = item.value
+                is ItemWithInternalAndExternalState.ExternalStateItem -> currentConsumedExternalState = item.value
+                is ItemWithInternalAndExternalState.SideEffectItem -> Unit
+            }
+        }
+    }
 }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsWithExternalStateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsWithExternalStateTest.kt
@@ -25,6 +25,7 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.fail
 
 class ItemsWithExternalStateTest {
 
@@ -97,10 +98,10 @@ class ItemsWithExternalStateTest {
             containerHost.newState(state2)
             containerHost.newSideEffect(sideEffect2)
 
-            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(1)), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(3), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(2)), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(4), awaitItem())
+            assertEquals(Item.StateItem(InternalState(1)), awaitItem())
+            assertEquals(Item.SideEffectItem(3), awaitItem())
+            assertEquals(Item.StateItem(InternalState(2)), awaitItem())
+            assertEquals(Item.SideEffectItem(4), awaitItem())
         }
     }
 
@@ -117,10 +118,10 @@ class ItemsWithExternalStateTest {
             containerHost.newState(state2)
             containerHost.newSideEffect(sideEffect2)
 
-            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("1")), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(3), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("2")), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(4), awaitItem())
+            assertEquals(Item.StateItem(ExternalState("1")), awaitItem())
+            assertEquals(Item.SideEffectItem(3), awaitItem())
+            assertEquals(Item.StateItem(ExternalState("2")), awaitItem())
+            assertEquals(Item.SideEffectItem(4), awaitItem())
         }
     }
 
@@ -137,12 +138,80 @@ class ItemsWithExternalStateTest {
             containerHost.newState(state2)
             containerHost.newSideEffect(sideEffect2)
 
-            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(1)), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("1")), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(3), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(2)), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("2")), awaitItem())
-            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(4), awaitItem())
+            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(1)), awaitRawItem())
+            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("1")), awaitRawItem())
+            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(3), awaitRawItem())
+            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(2)), awaitRawItem())
+            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("2")), awaitRawItem())
+            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(4), awaitRawItem())
+        }
+    }
+
+    @Test
+    fun internal_items_can_be_drained_until_a_side_effect() = runTest {
+        ItemTestMiddleware(this).testWithInternalState(this) {
+            containerHost.newState(1)
+            containerHost.newState(2)
+            containerHost.newSideEffect(3)
+
+            var latest: InternalState? = null
+            repeat(10) {
+                when (val item = awaitItem()) {
+                    is Item.StateItem -> latest = item.value
+                    is Item.SideEffectItem -> {
+                        assertEquals(3, item.value)
+                        assertEquals(InternalState(2), latest)
+                        return@testWithInternalState
+                    }
+                }
+            }
+            fail("Expected a side effect but none was received")
+        }
+    }
+
+    @Test
+    fun external_items_can_be_drained_until_a_side_effect() = runTest {
+        ItemTestMiddleware(this).testWithExternalState(this) {
+            containerHost.newState(1)
+            containerHost.newState(2)
+            containerHost.newSideEffect(3)
+
+            var latest: ExternalState? = null
+            repeat(10) {
+                when (val item = awaitItem()) {
+                    is Item.StateItem -> latest = item.value
+                    is Item.SideEffectItem -> {
+                        assertEquals(3, item.value)
+                        assertEquals(ExternalState("2"), latest)
+                        return@testWithExternalState
+                    }
+                }
+            }
+            fail("Expected a side effect but none was received")
+        }
+    }
+
+    @Test
+    fun await_item_advances_internal_state_for_relative_assertions() = runTest {
+        ItemTestMiddleware(this).testWithInternalState(this) {
+            containerHost.newState(1)
+            containerHost.newState(2)
+
+            // Consuming a state via awaitItem must advance the baseline used by relative assertions
+            assertEquals(Item.StateItem(InternalState(1)), awaitItem())
+            expectInternalState { copy(count = count + 1) }
+        }
+    }
+
+    @Test
+    fun await_item_advances_external_state_for_relative_assertions() = runTest {
+        ItemTestMiddleware(this).testWithExternalState(this) {
+            containerHost.newState(1)
+            containerHost.newState(2)
+
+            // Consuming a state via awaitItem must advance the baseline used by relative assertions
+            assertEquals(Item.StateItem(ExternalState("1")), awaitItem())
+            expectExternalState { copy(count = (count.toInt() + 1).toString()) }
         }
     }
 

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsWithExternalStateTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ItemsWithExternalStateTest.kt
@@ -138,12 +138,12 @@ class ItemsWithExternalStateTest {
             containerHost.newState(state2)
             containerHost.newSideEffect(sideEffect2)
 
-            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(1)), awaitRawItem())
-            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("1")), awaitRawItem())
-            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(3), awaitRawItem())
-            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(2)), awaitRawItem())
-            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("2")), awaitRawItem())
-            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(4), awaitRawItem())
+            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(1)), awaitItem())
+            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("1")), awaitItem())
+            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(3), awaitItem())
+            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(2)), awaitItem())
+            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("2")), awaitItem())
+            assertEquals(ItemWithInternalAndExternalState.SideEffectItem(4), awaitItem())
         }
     }
 
@@ -211,6 +211,45 @@ class ItemsWithExternalStateTest {
 
             // Consuming a state via awaitItem must advance the baseline used by relative assertions
             assertEquals(Item.StateItem(ExternalState("1")), awaitItem())
+            expectExternalState { copy(count = (count.toInt() + 1).toString()) }
+        }
+    }
+
+    @Test
+    fun internal_and_external_items_can_be_drained_until_a_side_effect() = runTest {
+        ItemTestMiddleware(this).testWithInternalAndExternalState(this) {
+            containerHost.newState(1)
+            containerHost.newState(2)
+            containerHost.newSideEffect(3)
+
+            var latestInternal: InternalState? = null
+            var latestExternal: ExternalState? = null
+            repeat(10) {
+                when (val item = awaitItem()) {
+                    is ItemWithInternalAndExternalState.InternalStateItem -> latestInternal = item.value
+                    is ItemWithInternalAndExternalState.ExternalStateItem -> latestExternal = item.value
+                    is ItemWithInternalAndExternalState.SideEffectItem -> {
+                        assertEquals(3, item.value)
+                        assertEquals(InternalState(2), latestInternal)
+                        assertEquals(ExternalState("2"), latestExternal)
+                        return@testWithInternalAndExternalState
+                    }
+                }
+            }
+            fail("Expected a side effect but none was received")
+        }
+    }
+
+    @Test
+    fun await_item_advances_state_for_relative_internal_and_external_assertions() = runTest {
+        ItemTestMiddleware(this).testWithInternalAndExternalState(this) {
+            containerHost.newState(1)
+            containerHost.newState(2)
+
+            // Consuming states via awaitItem must advance the baselines used by relative assertions
+            assertEquals(ItemWithInternalAndExternalState.InternalStateItem(InternalState(1)), awaitItem())
+            assertEquals(ItemWithInternalAndExternalState.ExternalStateItem(ExternalState("1")), awaitItem())
+            expectInternalState { copy(count = count + 1) }
             expectExternalState { copy(count = (count.toInt() + 1).toString()) }
         }
     }

--- a/website/docs/Test/index.md
+++ b/website/docs/Test/index.md
@@ -250,6 +250,41 @@ fun exampleTest() = runTest {
     }
 ```
 
+### Draining items of an unknown type
+
+`awaitState` / `awaitInternalState` / `awaitExternalState` and `awaitSideEffect`
+fail if the next emission isn't the type you asked for. When the ordering of
+states and side effects isn't deterministic - for example several
+`repeatOnSubscription` collectors and a background coroutine all updating state
+while a side effect fires - you can't assert a fixed sequence.
+
+For these cases `awaitItem()` returns the next emission as an `Item`, letting you
+branch on whether it's a state or a side effect. This is handy for draining past
+states until the side effect you care about arrives. Consuming a state via
+`awaitItem()` advances the state used by subsequent relative assertions
+(e.g. `expectState`), just like `awaitState()`.
+
+```kotlin
+@Test
+fun exampleTest() = runTest {
+        ExampleViewModel().testWithInternalState(this) {
+            runOnCreate()
+            containerHost.refresh()
+
+            var latest: State? = null
+            repeat(50) {
+                when (val item = awaitItem()) {
+                    is Item.StateItem -> latest = item.value
+                    is Item.SideEffectItem -> {
+                        assertEquals(SideEffect.ScrollToTop, item.value)
+                        return@testWithInternalState
+                    }
+                }
+            }
+        }
+    }
+```
+
 ### Unfinished intents
 
 Any intents that are still running at the end of the test will cause the test to

--- a/website/docs/Test/index.md
+++ b/website/docs/Test/index.md
@@ -264,6 +264,11 @@ states until the side effect you care about arrives. Consuming a state via
 `awaitItem()` advances the state used by subsequent relative assertions
 (e.g. `expectState`), just like `awaitState()`.
 
+`awaitItem()` is available on all of the single- and combined-state test
+contexts. On `testWithInternalAndExternalState` it returns an
+`ItemWithInternalAndExternalState`, which additionally distinguishes internal
+from external states.
+
 ```kotlin
 @Test
 fun exampleTest() = runTest {


### PR DESCRIPTION
## Why

Closes #343. Migrating from 11.x to 12.0, users lost the public `awaitItem()` that `test { }` provided. The new single-state contexts only expose `awaitInternalState()` / `awaitExternalState()` / `awaitSideEffect()`, each of which fails if the next emission isn't the exact expected type. There's no way to pull the next item when you don't know whether it's a state or a side effect — which is needed for ViewModels with non-deterministic ordering (e.g. several `repeatOnSubscription` collectors plus a background coroutine mutating state while a side effect fires). Today that forces a fallback to the deprecated `test { }`.

## What

- Expose a public `awaitItem(): Item<STATE, SIDE_EFFECT>` on `OrbitScopedTestContextInternal` and `OrbitScopedTestContextExternal`, returning the existing two-variant `Item` type.
- For consistency, `OrbitScopedTestContextInternalAndExternal` also gets a public `awaitItem()`, but returning the already-public three-variant `ItemWithInternalAndExternalState` (internal + external + side effect), which the two-variant `Item` can't model.
- Consuming a state via `awaitItem()` now advances the consumed-state baseline used by relative assertions (`expectInternalState { copy(...) }` / `expectExternalState { }` / `expect*StateOn`), matching `awaitInternalState()`/`awaitExternalState()`. Without this, mixing `awaitItem()` with a relative `expect*State` would assert against a stale baseline — a real bug. (The legacy `OrbitTestContext` has this footgun; left unchanged to avoid scope creep.)
- Renamed the base `internal awaitItem()` → `awaitRawItem()` to free the `awaitItem` name for the public typed accessors (no ABI impact — internal members aren't in the API dump).

## Testing

- New tests in `ItemsWithExternalStateTest` cover the drain-until-side-effect pattern for both contexts and a regression guarding the consumed-state baseline fix.
- `./gradlew :orbit-test:jvmTest` and `:orbit-test:apiCheck` pass; API dumps regenerated via `apiDump`.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
