### PR TITLE
Fix coroutine resource leaks and CancellationException handling

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/idling/OperatorIdlingExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/idling/OperatorIdlingExtensions.kt
@@ -31,7 +31,9 @@ public suspend fun <O : Operator<*, *>, T> ContainerContext<*, *>.withIdling(
     block: suspend O.() -> T
 ): T {
     if (operator.registerIdling) settings.idlingRegistry.increment()
-    return block(operator).also {
+    return try {
+        block(operator)
+    } finally {
         if (operator.registerIdling) settings.idlingRegistry.decrement()
     }
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/idling/SimpleIdlingExtensions.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/idling/SimpleIdlingExtensions.kt
@@ -27,7 +27,9 @@ public suspend fun <STATE : Any, SIDE_EFFECT : Any> ContainerContext<STATE, SIDE
     block: suspend ContainerContext<STATE, SIDE_EFFECT>.() -> Unit
 ) {
     if (registerIdling) settings.idlingRegistry.increment()
-    return block().also {
+    return try {
+        block()
+    } finally {
         if (registerIdling) settings.idlingRegistry.decrement()
     }
 }

--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -20,6 +20,7 @@
 
 package org.orbitmvi.orbit.internal
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
@@ -132,6 +133,7 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
                             intentLaunchingDispatcher
                     launch(exceptionHandlerContext) {
                         runCatching { pluginContext.intent() }.onFailure { e ->
+                            if (e is CancellationException) throw e
                             settings.exceptionHandler?.handleException(coroutineContext, e) ?: throw e
                         }
                     }.invokeOnCompletion { job.complete() }

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/idling/OperatorIdlingExtensionsTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/idling/OperatorIdlingExtensionsTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit.idling
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.orbitmvi.orbit.RealSettings
+import org.orbitmvi.orbit.annotation.OrbitInternal
+import org.orbitmvi.orbit.internal.repeatonsubscription.TestSubscribedCounter
+import org.orbitmvi.orbit.syntax.ContainerContext
+import org.orbitmvi.orbit.syntax.Operator
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@OptIn(OrbitInternal::class)
+internal class OperatorIdlingExtensionsTest {
+
+    private val idlingResource = TestIdlingResource()
+
+    private val containerContext = ContainerContext<Int, Int>(
+        settings = RealSettings(idlingRegistry = idlingResource),
+        postSideEffect = {},
+        reduce = {},
+        subscribedCounter = TestSubscribedCounter(),
+        stateFlow = MutableStateFlow(0),
+    )
+
+    @Test
+    fun idling_is_registered_around_the_block() = runTest {
+        val result = containerContext.withIdling(TestOperator(registerIdling = true)) {
+            assertEquals(1, idlingResource.counter())
+            "result"
+        }
+
+        assertEquals("result", result)
+        assertEquals(0, idlingResource.counter())
+    }
+
+    @Test
+    fun idling_is_not_registered_when_disabled() = runTest {
+        containerContext.withIdling(TestOperator(registerIdling = false)) {
+            assertEquals(0, idlingResource.counter())
+        }
+
+        assertEquals(0, idlingResource.counter())
+    }
+
+    @Test
+    fun idling_is_decremented_when_the_block_throws() = runTest {
+        assertFailsWith<IllegalStateException> {
+            containerContext.withIdling(TestOperator(registerIdling = true)) {
+                error("boom")
+            }
+        }
+
+        assertEquals(0, idlingResource.counter())
+    }
+
+    private class TestOperator(override val registerIdling: Boolean) : Operator<Int, Int>
+
+    private class TestIdlingResource : IdlingResource {
+        private val counter = AtomicInt(0)
+
+        override fun increment() {
+            counter.incrementAndFetch()
+        }
+
+        override fun decrement() {
+            counter.decrementAndFetch()
+        }
+
+        override fun close() = Unit
+
+        fun counter() = counter.load()
+    }
+}

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/internal/ContainerExceptionHandlerTest.kt
@@ -17,6 +17,7 @@
 package org.orbitmvi.orbit.internal
 
 import app.cash.turbine.test
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -92,6 +93,36 @@ internal class ContainerExceptionHandlerTest {
                 cancel()
             }
             cancelAndIgnoreRemainingItems()
+        }
+    }
+
+    @Test
+    fun cancellation_exception_thrown_inside_intent_is_not_forwarded_to_handler() = runTest {
+        val exceptions = Channel<Throwable>(capacity = Channel.BUFFERED)
+        val exceptionHandler = CoroutineExceptionHandler { _, throwable -> exceptions.trySend(throwable) }
+
+        val container = backgroundScope.orbitContainer<Int, Nothing>(
+            initialState = Random.nextInt(),
+            buildSettings = {
+                this.exceptionHandler = exceptionHandler
+            }
+        )
+
+        // A CancellationException raised inside an intent must be re-thrown to honour structured
+        // concurrency, not swallowed by being routed through the exception handler.
+        container.orbit {
+            throw CancellationException("cancelled inside intent")
+        }.join()
+
+        // A genuine failure raised afterwards must still reach the handler. As it arrives second,
+        // observing it first proves the CancellationException was never forwarded.
+        container.orbit {
+            throw IllegalStateException()
+        }.join()
+
+        exceptions.consumeAsFlow().test {
+            assertIs<IllegalStateException>(awaitItem())
+            cancel()
         }
     }
 

--- a/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslIdlingTest.kt
+++ b/orbit-core/src/commonTest/kotlin/org/orbitmvi/orbit/syntax/simple/SimpleDslIdlingTest.kt
@@ -20,6 +20,7 @@
 
 package org.orbitmvi.orbit.syntax.simple
 
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -109,12 +110,38 @@ internal class SimpleDslIdlingTest {
         }
     }
 
-    private fun CoroutineScope.createContainerHost(): OrbitContainerHost<TestState, TestState, Int> {
+    @Test
+    fun idle_after_running_when_intent_throws() = runTest {
+        val containerHost = backgroundScope.createContainerHost(
+            exceptionHandler = CoroutineExceptionHandler { _, _ -> }
+        )
+
+        val mutex = Mutex(locked = true)
+
+        containerHost.intent {
+            try {
+                error("boom")
+            } finally {
+                mutex.unlock()
+            }
+        }
+
+        mutex.withLock {
+            assertEventually {
+                assertTrue { testIdlingResource.isIdle() }
+            }
+        }
+    }
+
+    private fun CoroutineScope.createContainerHost(
+        exceptionHandler: CoroutineExceptionHandler? = null
+    ): OrbitContainerHost<TestState, TestState, Int> {
         return object : OrbitContainerHost<TestState, TestState, Int> {
             override val container: OrbitContainer<TestState, TestState, Int> = orbitContainer(
                 initialState = TestState(0),
                 buildSettings = {
                     idlingRegistry = testIdlingResource
+                    this.exceptionHandler = exceptionHandler
                 },
             )
         }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Timeout.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Timeout.kt
@@ -55,15 +55,16 @@ private suspend fun <T> withWallClockTimeout(
     @OptIn(DelicateCoroutinesApi::class)
     val timeoutJob = GlobalScope.launch(Dispatchers.Default) { delay(timeout) }
 
-    select {
-        blockDeferred.onAwait { result ->
-            timeoutJob.cancel()
-            result
+    try {
+        select {
+            blockDeferred.onAwait { result -> result }
+            timeoutJob.onJoin {
+                blockDeferred.cancel()
+                throw OrbitTimeoutCancellationException("Timed out waiting for remaining intents to complete for $timeout")
+            }
         }
-        timeoutJob.onJoin {
-            blockDeferred.cancel()
-            throw OrbitTimeoutCancellationException("Timed out waiting for remaining intents to complete for $timeout")
-        }
+    } finally {
+        timeoutJob.cancel()
     }
 }
 


### PR DESCRIPTION
Fixes #333.

Three coroutine resource-safety bugs in `orbit-core` and `orbit-test`, all sharing one root cause — cleanup code skipped on exception: the idling counter now decrements in a `finally` so it can't leak when an intent throws, `RealContainer` re-throws `CancellationException` before the exception handler runs so structured concurrency propagates cancellation, and `withWallClockTimeout` cancels its `GlobalScope` timeout job in a `finally` so it never leaks. Added regression tests for the idling leak and the cancellation-forwarding bug, both of which fail on the un-fixed source and pass with the fixes. The `GlobalScope` leak isn't cleanly unit-testable so it stays covered by the existing timeout suite.

Confident this won't break production: full `:orbit-core:jvmTest` and `:orbit-test:jvmTest` suites and `detekt` pass, and the two new tests were verified to fail before the fixes and pass after.