### PR TITLE
Fix off-main-thread teardown from Unconfined produce in RealContainer (#328)

### DIFF
--- a/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
+++ b/orbit-core/src/commonMain/kotlin/org/orbitmvi/orbit/internal/RealContainer.kt
@@ -23,19 +23,17 @@ package org.orbitmvi.orbit.internal
 import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.channels.produce
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.job
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -115,13 +113,14 @@ public class RealContainer<INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFE
         pluginContext.orbitIntent()
     }
 
-    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
     private fun initialiseIfNeeded() {
         if (initialised.compareAndSet(expectedValue = false, newValue = true)) {
-            scope.produce<Unit>(Dispatchers.Unconfined) {
-                awaitClose {
-                    settings.idlingRegistry.close()
-                }
+            // Tie idling registry teardown to scope cancellation. Registered synchronously here (no
+            // coroutine/dispatcher) so it can't be lost if the scope is cancelled before a dispatched
+            // coroutine would have started, and so it doesn't install an unconfined event loop on the
+            // caller's thread (see https://github.com/orbit-mvi/orbit-mvi/issues/328).
+            scope.coroutineContext.job.invokeOnCompletion {
+                settings.idlingRegistry.close()
             }
 
             scope.launch(CoroutineName(COROUTINE_NAME_EVENT_LOOP)) {

--- a/orbit-viewmodel/src/androidHostTest/kotlin/org/orbitmvi/orbit/viewmodel/AndroidIdlingResourceTest.kt
+++ b/orbit-viewmodel/src/androidHostTest/kotlin/org/orbitmvi/orbit/viewmodel/AndroidIdlingResourceTest.kt
@@ -314,6 +314,9 @@ class AndroidIdlingResourceTest {
 
             scope.cancel()
 
+            // Teardown fires when the container scope's job completes (on its event loop dispatcher),
+            // shortly after cancellation rather than synchronously on the cancelling thread.
+            awaitIdlingResourceUnregistration()
             assertEquals(0, IdlingRegistry.getInstance().resources.size)
         }
     }


### PR DESCRIPTION
## Why

`RealContainer` bound its idling-registry teardown via `produce(Dispatchers.Unconfined) { awaitClose { idlingRegistry.close() } }`. The `Unconfined` dispatcher installs a thread-local unconfined event loop on a background worker thread, which can pump unrelated queued continuations (e.g. Compose recomposition) off the main thread — the likely cause of the intermittent `CalledFromWrongThreadException` in #328.

## What

Replaced that idiom with `scope.coroutineContext.job.invokeOnCompletion { idlingRegistry.close() }`, which registers the teardown synchronously at init (preserving the fix from d80d53b9 that stops the callback being lost on a fast cancel) without any coroutine, dispatcher, or event loop. Teardown now fires on scope completion rather than eagerly on the cancelling thread, so `AndroidIdlingResourceTest.cancelling_scope_removes_idling_resource` was updated to await unregistration before asserting (using the helper it already uses in `after()`).

## Testing

`:orbit-core:jvmTest` and `:orbit-viewmodel:testAndroidHostTest` (including all `AndroidIdlingResourceTest` cases) pass. The reported crash is intermittent instrumented-test behaviour, so full confirmation would need a run against the reporter's repro, but the offending unconfined event loop is removed.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)