### PR TITLE
Surface intent exceptions when awaiting state in tests

### DIFF
--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/ExternalTest.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/ExternalTest.kt
@@ -18,9 +18,7 @@ package org.orbitmvi.orbit.test
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.test.TestScope
@@ -64,15 +62,8 @@ public suspend fun <INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFECT : An
     val testDispatcher =
         settings.dispatcherOverride ?: testScope.backgroundScope.coroutineContext[ContinuationInterceptor.Key] as? CoroutineDispatcher
 
-    var caughtException: Throwable? = null
-
-    val testExceptionHandler = settings.exceptionHandlerOverride
-        ?: containerHost.container.settings.exceptionHandler
-        ?: CoroutineExceptionHandler { _, exception ->
-            if (exception !is CancellationException) {
-                caughtException = exception
-            }
-        }
+    val exceptionCatcher = OrbitTestExceptionCatcher()
+    val testExceptionHandler = exceptionCatcher.resolveHandler(settings, containerHost.container.settings.exceptionHandler)
 
     container.findTestContainer().test(
         initialState = initialState,
@@ -83,31 +74,33 @@ public suspend fun <INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFECT : An
     val resolvedInitialState: INTERNAL_STATE =
         initialState ?: containerHost.container.findTestContainer().originalInitialState
 
-    buildList {
-        add(
-            container.stateFlow
-                .map<INTERNAL_STATE, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> {
-                    InternalStateItem(it)
-                }
-        )
+    exceptionCatcher.runFailingFast {
+        buildList {
+            add(
+                container.stateFlow
+                    .map<INTERNAL_STATE, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> {
+                        InternalStateItem(it)
+                    }
+            )
 
-        add(
-            container.sideEffectFlow
-                .map<SIDE_EFFECT, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> { SideEffectItem(it) }
-        )
-    }.merge().test(timeout = timeout) {
-        OrbitScopedTestContextInternal(
-            containerHost,
-            resolvedInitialState,
-            this as ReceiveTurbine<ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>>,
-        ).apply {
-            if (settings.autoCheckInitialState) {
-                assertEquals(resolvedInitialState, awaitInternalState())
-            }
-            validate(this)
-            caughtException?.let { throw it }
-            withAppropriateTimeout(timeout ?: 1.seconds) {
-                container.findTestContainer().joinIntents()
+            add(
+                container.sideEffectFlow
+                    .map<SIDE_EFFECT, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> { SideEffectItem(it) }
+            )
+        }.merge().test(timeout = timeout) {
+            OrbitScopedTestContextInternal(
+                containerHost,
+                resolvedInitialState,
+                this as ReceiveTurbine<ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>>,
+            ).apply {
+                if (settings.autoCheckInitialState) {
+                    assertEquals(resolvedInitialState, awaitInternalState())
+                }
+                validate(this)
+                exceptionCatcher.caughtException?.let { throw it }
+                withAppropriateTimeout(timeout ?: 1.seconds) {
+                    container.findTestContainer().joinIntents()
+                }
             }
         }
     }
@@ -127,15 +120,8 @@ public suspend fun <INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFECT : An
     val testDispatcher =
         settings.dispatcherOverride ?: testScope.backgroundScope.coroutineContext[ContinuationInterceptor.Key] as? CoroutineDispatcher
 
-    var caughtException: Throwable? = null
-
-    val testExceptionHandler = settings.exceptionHandlerOverride
-        ?: containerHost.container.settings.exceptionHandler
-        ?: CoroutineExceptionHandler { _, exception ->
-            if (exception !is CancellationException) {
-                caughtException = exception
-            }
-        }
+    val exceptionCatcher = OrbitTestExceptionCatcher()
+    val testExceptionHandler = exceptionCatcher.resolveHandler(settings, containerHost.container.settings.exceptionHandler)
 
     container.findTestContainer().test(
         initialState = initialState,
@@ -146,31 +132,33 @@ public suspend fun <INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFECT : An
     val resolvedInitialState: INTERNAL_STATE =
         initialState ?: containerHost.container.findTestContainer().originalInitialState
 
-    buildList {
-        add(
-            container.externalStateFlow
-                .map<EXTERNAL_STATE, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> {
-                    ExternalStateItem(it)
-                }
-        )
+    exceptionCatcher.runFailingFast {
+        buildList {
+            add(
+                container.externalStateFlow
+                    .map<EXTERNAL_STATE, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> {
+                        ExternalStateItem(it)
+                    }
+            )
 
-        add(
-            container.sideEffectFlow
-                .map<SIDE_EFFECT, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> { SideEffectItem(it) }
-        )
-    }.merge().test(timeout = timeout) {
-        OrbitScopedTestContextExternal(
-            containerHost,
-            resolvedInitialState,
-            this as ReceiveTurbine<ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>>,
-        ).apply {
-            if (settings.autoCheckInitialState) {
-                assertEquals(container.findTransformState()(resolvedInitialState), awaitExternalState())
-            }
-            validate(this)
-            caughtException?.let { throw it }
-            withAppropriateTimeout(timeout ?: 1.seconds) {
-                container.findTestContainer().joinIntents()
+            add(
+                container.sideEffectFlow
+                    .map<SIDE_EFFECT, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> { SideEffectItem(it) }
+            )
+        }.merge().test(timeout = timeout) {
+            OrbitScopedTestContextExternal(
+                containerHost,
+                resolvedInitialState,
+                this as ReceiveTurbine<ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>>,
+            ).apply {
+                if (settings.autoCheckInitialState) {
+                    assertEquals(container.findTransformState()(resolvedInitialState), awaitExternalState())
+                }
+                validate(this)
+                exceptionCatcher.caughtException?.let { throw it }
+                withAppropriateTimeout(timeout ?: 1.seconds) {
+                    container.findTestContainer().joinIntents()
+                }
             }
         }
     }
@@ -190,15 +178,8 @@ public suspend fun <INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFECT : An
     val testDispatcher =
         settings.dispatcherOverride ?: testScope.backgroundScope.coroutineContext[ContinuationInterceptor.Key] as? CoroutineDispatcher
 
-    var caughtException: Throwable? = null
-
-    val testExceptionHandler = settings.exceptionHandlerOverride
-        ?: containerHost.container.settings.exceptionHandler
-        ?: CoroutineExceptionHandler { _, exception ->
-            if (exception !is CancellationException) {
-                caughtException = exception
-            }
-        }
+    val exceptionCatcher = OrbitTestExceptionCatcher()
+    val testExceptionHandler = exceptionCatcher.resolveHandler(settings, containerHost.container.settings.exceptionHandler)
 
     container.findTestContainer().test(
         initialState = initialState,
@@ -209,37 +190,39 @@ public suspend fun <INTERNAL_STATE : Any, EXTERNAL_STATE : Any, SIDE_EFFECT : An
     val resolvedInitialState: INTERNAL_STATE =
         initialState ?: containerHost.container.findTestContainer().originalInitialState
 
-    buildList {
-        add(
-            container.stateFlow
-                .map<INTERNAL_STATE, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> {
-                    InternalStateItem(it)
+    exceptionCatcher.runFailingFast {
+        buildList {
+            add(
+                container.stateFlow
+                    .map<INTERNAL_STATE, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> {
+                        InternalStateItem(it)
+                    }
+            )
+            add(
+                container.externalStateFlow
+                    .map<EXTERNAL_STATE, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> {
+                        ExternalStateItem(it)
+                    }
+            )
+            add(
+                container.sideEffectFlow
+                    .map<SIDE_EFFECT, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> { SideEffectItem(it) }
+            )
+        }.merge().test(timeout = timeout) {
+            OrbitScopedTestContextInternalAndExternal(
+                containerHost,
+                resolvedInitialState,
+                this as ReceiveTurbine<ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>>,
+            ).apply {
+                if (settings.autoCheckInitialState) {
+                    assertEquals(resolvedInitialState, awaitInternalState())
+                    assertEquals(container.findTransformState()(resolvedInitialState), awaitExternalState())
                 }
-        )
-        add(
-            container.externalStateFlow
-                .map<EXTERNAL_STATE, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> {
-                    ExternalStateItem(it)
+                validate(this)
+                exceptionCatcher.caughtException?.let { throw it }
+                withAppropriateTimeout(timeout ?: 1.seconds) {
+                    container.findTestContainer().joinIntents()
                 }
-        )
-        add(
-            container.sideEffectFlow
-                .map<SIDE_EFFECT, ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>> { SideEffectItem(it) }
-        )
-    }.merge().test(timeout = timeout) {
-        OrbitScopedTestContextInternalAndExternal(
-            containerHost,
-            resolvedInitialState,
-            this as ReceiveTurbine<ItemWithInternalAndExternalState<INTERNAL_STATE, EXTERNAL_STATE, SIDE_EFFECT>>,
-        ).apply {
-            if (settings.autoCheckInitialState) {
-                assertEquals(resolvedInitialState, awaitInternalState())
-                assertEquals(container.findTransformState()(resolvedInitialState), awaitExternalState())
-            }
-            validate(this)
-            caughtException?.let { throw it }
-            withAppropriateTimeout(timeout ?: 1.seconds) {
-                container.findTestContainer().joinIntents()
             }
         }
     }

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestExceptionCatcher.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/OrbitTestExceptionCatcher.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Mikołaj Leszczyński & Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.orbitmvi.orbit.test
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Captures exceptions thrown by intents during a test.
+ *
+ * When neither a [TestSettings.exceptionHandlerOverride] nor a container-level
+ * [org.orbitmvi.orbit.RealSettings.exceptionHandler] is supplied, this installs a default handler that both stores the
+ * exception (re-thrown after the `validate` block for tests that never await) and forwards it to [runFailingFast], which
+ * fails the test immediately with the real exception instead of letting an `awaitItem`/`awaitState` time out.
+ */
+internal class OrbitTestExceptionCatcher {
+    private val exceptionChannel = Channel<Throwable>(Channel.UNLIMITED)
+
+    var caughtException: Throwable? = null
+        private set
+
+    /**
+     * Resolves the [CoroutineExceptionHandler] to use for the test. An explicit [TestSettings.exceptionHandlerOverride]
+     * or [containerExceptionHandler] takes precedence and preserves existing behaviour; otherwise the fail-fast default
+     * handler is installed.
+     */
+    fun resolveHandler(
+        settings: TestSettings,
+        containerExceptionHandler: CoroutineExceptionHandler?,
+    ): CoroutineExceptionHandler =
+        settings.exceptionHandlerOverride
+            ?: containerExceptionHandler
+            ?: CoroutineExceptionHandler { _, exception ->
+                if (exception !is CancellationException) {
+                    caughtException = exception
+                    exceptionChannel.trySend(exception)
+                }
+            }
+
+    /**
+     * Runs [block] alongside a watcher that rethrows the first exception captured by the default handler. When an intent
+     * throws while the test is suspended (e.g. inside `awaitState`), the watcher fails the enclosing scope with the real
+     * exception so the test fails fast with the actual cause rather than a Turbine timeout.
+     */
+    suspend fun <T> runFailingFast(block: suspend () -> T): T = coroutineScope {
+        val watcher = launch {
+            throw exceptionChannel.receive()
+        }
+        try {
+            block()
+        } finally {
+            watcher.cancel()
+        }
+    }
+}

--- a/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Test.kt
+++ b/orbit-test/src/commonMain/kotlin/org/orbitmvi/orbit/test/Test.kt
@@ -17,7 +17,6 @@
 package org.orbitmvi.orbit.test
 
 import app.cash.turbine.test
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.flow.map
@@ -66,15 +65,8 @@ public suspend fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : OrbitContai
     val testDispatcher =
         settings.dispatcherOverride ?: testScope.backgroundScope.coroutineContext[ContinuationInterceptor.Key] as? CoroutineDispatcher
 
-    var caughtException: Throwable? = null
-
-    val testExceptionHandler = settings.exceptionHandlerOverride
-        ?: containerHost.container.settings.exceptionHandler
-        ?: CoroutineExceptionHandler { _, exception ->
-            if (exception !is CancellationException) {
-                caughtException = exception
-            }
-        }
+    val exceptionCatcher = OrbitTestExceptionCatcher()
+    val testExceptionHandler = exceptionCatcher.resolveHandler(settings, containerHost.container.settings.exceptionHandler)
 
     container.findTestContainer().test(
         initialState = initialState,
@@ -84,23 +76,25 @@ public suspend fun <STATE : Any, SIDE_EFFECT : Any, CONTAINER_HOST : OrbitContai
 
     val resolvedInitialState: STATE = initialState ?: containerHost.container.findTestContainer().originalInitialState
 
-    merge(
-        container.stateFlow.map<STATE, Item<STATE, SIDE_EFFECT>> { Item.StateItem(it) },
-        container.sideEffectFlow.map<SIDE_EFFECT, Item<STATE, SIDE_EFFECT>> { Item.SideEffectItem(it) }
-    ).test(timeout = timeout) {
-        OrbitTestContext(
-            containerHost,
-            resolvedInitialState,
-            this,
-            settings
-        ).apply {
-            if (settings.autoCheckInitialState) {
-                assertEquals(resolvedInitialState, awaitState())
-            }
-            validate(this)
-            caughtException?.let { throw it }
-            withAppropriateTimeout(timeout ?: 1.seconds) {
-                container.findTestContainer().joinIntents()
+    exceptionCatcher.runFailingFast {
+        merge(
+            container.stateFlow.map<STATE, Item<STATE, SIDE_EFFECT>> { Item.StateItem(it) },
+            container.sideEffectFlow.map<SIDE_EFFECT, Item<STATE, SIDE_EFFECT>> { Item.SideEffectItem(it) }
+        ).test(timeout = timeout) {
+            OrbitTestContext(
+                containerHost,
+                resolvedInitialState,
+                this,
+                settings
+            ).apply {
+                if (settings.autoCheckInitialState) {
+                    assertEquals(resolvedInitialState, awaitState())
+                }
+                validate(this)
+                exceptionCatcher.caughtException?.let { throw it }
+                withAppropriateTimeout(timeout ?: 1.seconds) {
+                    container.findTestContainer().joinIntents()
+                }
             }
         }
     }

--- a/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
+++ b/orbit-test/src/commonTest/kotlin/org/orbitmvi/orbit/test/ExceptionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Mikołaj Leszczyński & Appmattus Limited
+ * Copyright 2023-2026 Mikołaj Leszczyński & Appmattus Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,18 @@ package org.orbitmvi.orbit.test
 
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import org.orbitmvi.orbit.OrbitContainer
 import org.orbitmvi.orbit.OrbitContainerHost
 import org.orbitmvi.orbit.orbitContainer
 import kotlin.random.Random
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class ExceptionTest {
 
-    private val initialState = State()
+    private val initialState = InternalState()
 
     @Test
     fun exceptions_thrown_during_test_can_be_asserted_on() = runTest {
@@ -39,16 +42,63 @@ class ExceptionTest {
         }
     }
 
-    private inner class ExceptionTestMiddleware(scope: TestScope) : OrbitContainerHost<State, State, Int> {
-        override val container = scope.backgroundScope.orbitContainer<State, Int>(initialState)
+    @Test
+    fun exceptions_thrown_while_awaiting_internal_state_are_surfaced() = runTest {
+        val exception = assertFailsWith<IllegalStateException> {
+            ExceptionTestMiddleware(this).testWithInternalState(this) {
+                containerHost.boom()
+
+                awaitInternalState()
+            }
+        }
+
+        assertEquals("Boom!", exception.message)
+    }
+
+    @Test
+    fun exceptions_thrown_while_awaiting_external_state_are_surfaced() = runTest {
+        val exception = assertFailsWith<IllegalStateException> {
+            ExceptionTestMiddleware(this).testWithExternalState(this) {
+                containerHost.boom()
+
+                awaitExternalState()
+            }
+        }
+
+        assertEquals("Boom!", exception.message)
+    }
+
+    @Test
+    fun exceptions_thrown_while_awaiting_internal_and_external_state_are_surfaced() = runTest {
+        val exception = assertFailsWith<IllegalStateException> {
+            ExceptionTestMiddleware(this).testWithInternalAndExternalState(this) {
+                containerHost.boom()
+
+                awaitInternalState()
+            }
+        }
+
+        assertEquals("Boom!", exception.message)
+    }
+
+    private inner class ExceptionTestMiddleware(scope: TestScope) :
+        OrbitContainerHost<InternalState, ExternalState, Int> {
+        override val container: OrbitContainer<InternalState, ExternalState, Int> = scope.backgroundScope.orbitContainer(
+            initialState,
+            ::transformState
+        )
+
+        private fun transformState(internalState: InternalState): ExternalState = ExternalState(internalState.count.toString())
 
         fun boom() = intent {
             throw IllegalStateException("Boom!")
         }
     }
 
-    private data class State(
+    private data class InternalState(
         val count: Int = Random.nextInt(),
         val list: List<Int> = emptyList()
     )
+
+    private data class ExternalState(val count: String)
 }


### PR DESCRIPTION
Fixes #326. The test harness stored intent exceptions and only re-threw them after the `validate` block, so awaiting state after a throwing intent timed out in Turbine ("No value produced in 3s") and lost the real exception — forcing users to add a custom `TestSettings(exceptionHandlerOverride = ...)` to even see it.

This adds `OrbitTestExceptionCatcher`, which installs a fail-fast watcher for the default exception handler that rethrows the actual exception into the enclosing scope, failing the test immediately with the real cause. It only affects the default handler — a supplied `exceptionHandlerOverride` or container-level `exceptionHandler` keeps its existing behaviour, and the existing post-`validate` re-throw is preserved for tests that never await.

Wired into all four entry points (`testWithInternalState`, `testWithExternalState`, `testWithInternalAndExternalState`, and the deprecated `test`).

Verified via new `ExceptionTest` cases across all `testWith*State` entry points plus the existing `ContainerExceptionHandlerTest` regression suite; detekt is clean.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)